### PR TITLE
feat: AI-powered CDK deploy hang detector (reusable-cdk-deploy-monitor)

### DIFF
--- a/.github/workflows/reusable-cdk-deploy-monitor.yml
+++ b/.github/workflows/reusable-cdk-deploy-monitor.yml
@@ -68,7 +68,7 @@ jobs:
           set -euo pipefail
 
           HANG_THRESHOLD_SECONDS=$(( HANG_THRESHOLD_MINUTES * 60 ))
-          LAST_EVENT_TIME=0
+          LAST_EVENT_TIME=$(date -u +%s)
 
           TERMINAL_STATUSES="CREATE_COMPLETE UPDATE_COMPLETE DELETE_COMPLETE \
             CREATE_FAILED UPDATE_FAILED DELETE_FAILED \
@@ -116,11 +116,7 @@ jobs:
                 || echo "$LAST_EVENT_TIME")
 
               if [[ "$LATEST_EPOCH" -gt "$LAST_EVENT_TIME" ]]; then
-                if [[ "$LAST_EVENT_TIME" -eq 0 ]]; then
-                  echo "Initialized hang timer from last CF event: $LATEST_EVENT_TS"
-                else
-                  echo "New event at $LATEST_EVENT_TS -- resetting hang timer."
-                fi
+                echo "New event at $LATEST_EVENT_TS -- resetting hang timer."
                 LAST_EVENT_TIME=$LATEST_EPOCH
               fi
             fi
@@ -140,7 +136,7 @@ jobs:
           done
 
       - name: Analyse hang with AI and act
-        if: always()
+        if: always() && !cancelled()
         env:
           STACK_NAME: ${{ inputs.stack_name }}
           AWS_REGION: ${{ inputs.aws_region }}
@@ -247,7 +243,7 @@ jobs:
           done
 
       - name: Cancel stack update (if verdict is CANCEL and auto_cancel is true)
-        if: always()
+        if: always() && !cancelled()
         env:
           STACK_NAME: ${{ inputs.stack_name }}
           AWS_REGION: ${{ inputs.aws_region }}

--- a/.github/workflows/reusable-cdk-deploy-monitor.yml
+++ b/.github/workflows/reusable-cdk-deploy-monitor.yml
@@ -134,3 +134,156 @@ jobs:
 
             sleep "$POLL_INTERVAL_SECONDS"
           done
+
+      - name: Analyse hang with AI and act
+        if: always()
+        env:
+          STACK_NAME: ${{ inputs.stack_name }}
+          AWS_REGION: ${{ inputs.aws_region }}
+          LOG_GROUP_NAME: ${{ inputs.log_group_name }}
+          HANG_THRESHOLD_MINUTES: ${{ inputs.hang_threshold_minutes }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f /tmp/ai_trigger ]]; then
+            echo "No hang detected -- skipping AI analysis."
+            exit 0
+          fi
+
+          MAX_AI_RETRIES=3
+          AI_RETRIES=0
+
+          while [[ "$AI_RETRIES" -lt "$MAX_AI_RETRIES" ]]; do
+            echo "AI analysis attempt $((AI_RETRIES + 1)) of $MAX_AI_RETRIES"
+
+            # Fetch last 50 CloudFormation events
+            CF_EVENTS=$(aws cloudformation describe-stack-events \
+              --stack-name "$STACK_NAME" \
+              --region "$AWS_REGION" \
+              --max-items 50 \
+              --query 'StackEvents[*].{Time:Timestamp,Status:ResourceStatus,Resource:LogicalResourceId,Reason:ResourceStatusReason}' \
+              --output json 2>/dev/null || echo "[]")
+
+            # Fetch CloudWatch logs if log_group_name is set
+            CW_LOGS=""
+            if [[ -n "$LOG_GROUP_NAME" ]]; then
+              RESOLVED_LOG_GROUP=$(aws logs describe-log-groups \
+                --log-group-name-prefix "$LOG_GROUP_NAME" \
+                --region "$AWS_REGION" \
+                --query 'logGroups[0].logGroupName' \
+                --output text 2>/dev/null || echo "")
+
+              if [[ -n "$RESOLVED_LOG_GROUP" && "$RESOLVED_LOG_GROUP" != "None" ]]; then
+                echo "Fetching logs from: $RESOLVED_LOG_GROUP"
+                CW_LOGS=$(aws logs filter-log-events \
+                  --log-group-name "$RESOLVED_LOG_GROUP" \
+                  --region "$AWS_REGION" \
+                  --start-time "$(( ($(date -u +%s) - 1800) * 1000 ))" \
+                  --query 'events[*].message' \
+                  --output text 2>/dev/null \
+                  | tail -200 || echo "")
+              else
+                echo "Log group '$LOG_GROUP_NAME' not found -- skipping log fetch."
+              fi
+            fi
+
+            # Build prompt
+            MINUTES_ELAPSED=$(( (AI_RETRIES + 1) * HANG_THRESHOLD_MINUTES ))
+            CF_EVENTS_TRIMMED=$(echo "$CF_EVENTS" | head -c 8000)
+            PROMPT="Stack name: $STACK_NAME"$'\n'"Region: $AWS_REGION"$'\n'"Minutes since last CloudFormation event: $MINUTES_ELAPSED (attempt $((AI_RETRIES + 1)) of $MAX_AI_RETRIES)"$'\n\n'"Recent CloudFormation events (newest first, JSON):"$'\n'"$CF_EVENTS_TRIMMED"
+            if [[ -n "$CW_LOGS" ]]; then
+              CW_LOGS_TRIMMED=$(echo "$CW_LOGS" | head -c 4000)
+              PROMPT="$PROMPT"$'\n\n'"Recent application logs (last 200 lines):"$'\n'"$CW_LOGS_TRIMMED"
+            fi
+
+            # Call GitHub Models API
+            REQUEST_BODY=$(jq -n \
+              --arg prompt "$PROMPT" \
+              '{model:"gpt-4o",messages:[{role:"system",content:"You are a senior DevOps engineer expert in AWS CloudFormation and ECS deployments. Be concise and decisive."},{role:"user",content:("Is this CloudFormation deployment stuck (will not progress without intervention) or still making progress?\n\n" + $prompt + "\n\nReply with exactly CANCEL or WAIT on the first line, followed by a 2-sentence explanation.")}],max_tokens:300}')
+
+            RESPONSE=$(curl -sf \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://models.inference.ai.azure.com/chat/completions" \
+              -d "$REQUEST_BODY" 2>/dev/null || echo '{}')
+
+            AI_TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // "WAIT Could not reach AI model."' 2>/dev/null || echo "WAIT Could not parse AI response.")
+            VERDICT=$(echo "$AI_TEXT" | head -1 | grep -oE '^(CANCEL|WAIT)' || echo "WAIT")
+
+            echo "AI verdict: $VERDICT"
+            echo "AI explanation: $AI_TEXT"
+
+            # Post commit comment
+            COMMENT_BODY="### CDK Deploy Monitor"$'\n\n'"**Stack:** \`$STACK_NAME\`"$'\n'"**No new CloudFormation events for:** ${MINUTES_ELAPSED} minutes (check $((AI_RETRIES + 1)) of $MAX_AI_RETRIES)"$'\n\n'"**AI Verdict:** \`$VERDICT\`"$'\n\n'"${AI_TEXT}"$'\n\n'"---"$'\n'"*Posted by [reusable-cdk-deploy-monitor](https://github.com/geolonia/.github/blob/main/.github/workflows/reusable-cdk-deploy-monitor.yml)*"
+
+            gh api \
+              "repos/$REPO/commits/$SHA/comments" \
+              -f body="$COMMENT_BODY" \
+              2>/dev/null || echo "Warning: failed to post commit comment"
+
+            if [[ "$VERDICT" == "CANCEL" ]]; then
+              echo "CANCEL" > /tmp/ai_verdict
+              exit 0
+            fi
+
+            AI_RETRIES=$(( AI_RETRIES + 1 ))
+            if [[ "$AI_RETRIES" -lt "$MAX_AI_RETRIES" ]]; then
+              echo "AI said WAIT -- sleeping ${HANG_THRESHOLD_MINUTES}m before retry..."
+              sleep $(( HANG_THRESHOLD_MINUTES * 60 ))
+            else
+              echo "Max AI retries reached -- treating as CANCEL."
+              echo "CANCEL" > /tmp/ai_verdict
+            fi
+          done
+
+      - name: Cancel stack update (if verdict is CANCEL and auto_cancel is true)
+        if: always()
+        env:
+          STACK_NAME: ${{ inputs.stack_name }}
+          AWS_REGION: ${{ inputs.aws_region }}
+          AUTO_CANCEL: ${{ inputs.auto_cancel }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f /tmp/ai_verdict ]]; then
+            echo "No AI verdict -- nothing to cancel."
+            exit 0
+          fi
+
+          VERDICT=$(cat /tmp/ai_verdict)
+
+          if [[ "$VERDICT" != "CANCEL" ]]; then
+            echo "AI verdict is $VERDICT -- skipping cancellation."
+            exit 0
+          fi
+
+          if [[ "$AUTO_CANCEL" != "true" ]]; then
+            echo "auto_cancel=false -- advisory comment posted, not cancelling stack."
+            exit 0
+          fi
+
+          echo "Cancelling stack update: $STACK_NAME"
+          if aws cloudformation cancel-update-stack \
+            --stack-name "$STACK_NAME" \
+            --region "$AWS_REGION" 2>/tmp/cancel_error; then
+            echo "Stack update cancelled. CloudFormation is rolling back."
+            CANCEL_COMMENT="### CDK Deploy Monitor -- Update Cancelled"$'\n\n'"Stack \`$STACK_NAME\` update was cancelled (AI verdict: CANCEL, auto_cancel: true)."$'\n'"CloudFormation is rolling back. The deploy job will fail with a rollback error -- this is expected."
+            gh api \
+              "repos/$REPO/commits/$SHA/comments" \
+              -f body="$CANCEL_COMMENT" \
+              2>/dev/null || echo "Warning: failed to post cancel comment"
+          else
+            CANCEL_ERR=$(cat /tmp/cancel_error 2>/dev/null || echo "unknown error")
+            echo "cancel-update-stack failed: $CANCEL_ERR"
+            CANCEL_COMMENT="### CDK Deploy Monitor -- Cancel Attempt Failed"$'\n\n'"Tried to cancel \`$STACK_NAME\` but got an error:"$'\n'"$CANCEL_ERR"$'\n\n'"The stack may have already completed or been cancelled manually."
+            gh api \
+              "repos/$REPO/commits/$SHA/comments" \
+              -f body="$CANCEL_COMMENT" \
+              2>/dev/null || echo "Warning: failed to post error comment"
+          fi

--- a/.github/workflows/reusable-cdk-deploy-monitor.yml
+++ b/.github/workflows/reusable-cdk-deploy-monitor.yml
@@ -17,7 +17,7 @@ on:
         required: false
         default: ""
       hang_threshold_minutes:
-        description: "Minutes with no new CloudFormation events before asking AI"
+        description: "Minutes with no new CloudFormation events before asking AI (keep under 40 with defaults: up to 3x this value is spent in AI retries within the 120-minute job timeout)"
         type: number
         required: false
         default: 10
@@ -33,12 +33,12 @@ on:
         default: false
     secrets:
       aws_role_arn:
-        description: "OIDC IAM role ARN with cloudformation:DescribeStackEvents, CancelUpdateStack, and logs read permissions"
+        description: "OIDC IAM role ARN with cloudformation:DescribeStackEvents, DescribeStacks, CancelUpdateStack, and logs read permissions (see CdkDeployMonitor permission bundle)"
         required: true
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -68,7 +68,7 @@ jobs:
           set -euo pipefail
 
           HANG_THRESHOLD_SECONDS=$(( HANG_THRESHOLD_MINUTES * 60 ))
-          LAST_EVENT_TIME=$(date -u +%s)
+          LAST_EVENT_TIME=0
 
           TERMINAL_STATUSES="CREATE_COMPLETE UPDATE_COMPLETE DELETE_COMPLETE \
             CREATE_FAILED UPDATE_FAILED DELETE_FAILED \
@@ -116,7 +116,11 @@ jobs:
                 || echo "$LAST_EVENT_TIME")
 
               if [[ "$LATEST_EPOCH" -gt "$LAST_EVENT_TIME" ]]; then
-                echo "New event at $LATEST_EVENT_TS -- resetting hang timer."
+                if [[ "$LAST_EVENT_TIME" -eq 0 ]]; then
+                  echo "Initialized hang timer from last CF event: $LATEST_EVENT_TS"
+                else
+                  echo "New event at $LATEST_EVENT_TS -- resetting hang timer."
+                fi
                 LAST_EVENT_TIME=$LATEST_EPOCH
               fi
             fi
@@ -156,6 +160,7 @@ jobs:
           MAX_AI_RETRIES=3
           AI_RETRIES=0
 
+          HANG_DETECTED_AT=$(date -u +%s)
           while [[ "$AI_RETRIES" -lt "$MAX_AI_RETRIES" ]]; do
             echo "AI analysis attempt $((AI_RETRIES + 1)) of $MAX_AI_RETRIES"
 
@@ -191,7 +196,9 @@ jobs:
             fi
 
             # Build prompt
-            MINUTES_ELAPSED=$(( (AI_RETRIES + 1) * HANG_THRESHOLD_MINUTES ))
+            MINUTES_ELAPSED=$(( ($(date -u +%s) - HANG_DETECTED_AT) / 60 ))
+            # Ensure at least 1 minute is reported (first call)
+            [[ "$MINUTES_ELAPSED" -lt 1 ]] && MINUTES_ELAPSED=1
             CF_EVENTS_TRIMMED=$(echo "$CF_EVENTS" | head -c 8000)
             PROMPT="Stack name: $STACK_NAME"$'\n'"Region: $AWS_REGION"$'\n'"Minutes since last CloudFormation event: $MINUTES_ELAPSED (attempt $((AI_RETRIES + 1)) of $MAX_AI_RETRIES)"$'\n\n'"Recent CloudFormation events (newest first, JSON):"$'\n'"$CF_EVENTS_TRIMMED"
             if [[ -n "$CW_LOGS" ]]; then

--- a/.github/workflows/reusable-cdk-deploy-monitor.yml
+++ b/.github/workflows/reusable-cdk-deploy-monitor.yml
@@ -1,0 +1,69 @@
+name: "[REUSABLE] CDK Deploy Monitor"
+
+on:
+  workflow_call:
+    inputs:
+      stack_name:
+        description: "CloudFormation stack name to monitor"
+        type: string
+        required: true
+      aws_region:
+        description: "AWS region where the stack is deployed"
+        type: string
+        required: true
+      log_group_name:
+        description: "CloudWatch log group name or prefix pattern (optional; leave empty to skip log fetching)"
+        type: string
+        required: false
+        default: ""
+      hang_threshold_minutes:
+        description: "Minutes with no new CloudFormation events before asking AI"
+        type: number
+        required: false
+        default: 10
+      poll_interval_seconds:
+        description: "How often to poll CloudFormation events (seconds)"
+        type: number
+        required: false
+        default: 120
+      auto_cancel:
+        description: "Whether an AI verdict of CANCEL triggers cancel-update-stack (default: false = advisory only)"
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      aws_role_arn:
+        description: "OIDC IAM role ARN with cloudformation:DescribeStackEvents, CancelUpdateStack, and logs read permissions"
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  monitor:
+    name: Monitor CDK deploy (${{ inputs.stack_name }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws_role_arn }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Monitor stack
+        env:
+          STACK_NAME: ${{ inputs.stack_name }}
+          AWS_REGION: ${{ inputs.aws_region }}
+          LOG_GROUP_NAME: ${{ inputs.log_group_name }}
+          HANG_THRESHOLD_MINUTES: ${{ inputs.hang_threshold_minutes }}
+          POLL_INTERVAL_SECONDS: ${{ inputs.poll_interval_seconds }}
+          AUTO_CANCEL: ${{ inputs.auto_cancel }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          # TODO: polling loop (Task 2)
+          echo "Monitor started for stack: $STACK_NAME"
+          echo "Hang threshold: ${HANG_THRESHOLD_MINUTES}m, Poll interval: ${POLL_INTERVAL_SECONDS}s, Auto-cancel: $AUTO_CANCEL"

--- a/.github/workflows/reusable-cdk-deploy-monitor.yml
+++ b/.github/workflows/reusable-cdk-deploy-monitor.yml
@@ -64,6 +64,71 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
         run: |
-          # TODO: polling loop (Task 2)
-          echo "Monitor started for stack: $STACK_NAME"
-          echo "Hang threshold: ${HANG_THRESHOLD_MINUTES}m, Poll interval: ${POLL_INTERVAL_SECONDS}s, Auto-cancel: $AUTO_CANCEL"
+          set -euo pipefail
+
+          HANG_THRESHOLD_SECONDS=$(( HANG_THRESHOLD_MINUTES * 60 ))
+          LAST_EVENT_TIME=$(date -u +%s)
+
+          TERMINAL_STATUSES="CREATE_COMPLETE UPDATE_COMPLETE DELETE_COMPLETE \
+            CREATE_FAILED UPDATE_FAILED DELETE_FAILED \
+            ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE \
+            UPDATE_ROLLBACK_FAILED ROLLBACK_FAILED"
+
+          echo "Monitoring stack: $STACK_NAME"
+          echo "Hang threshold: ${HANG_THRESHOLD_MINUTES}m (${HANG_THRESHOLD_SECONDS}s)"
+          echo "Poll interval: ${POLL_INTERVAL_SECONDS}s"
+
+          while true; do
+            # Fetch stack status
+            STACK_STATUS=$(aws cloudformation describe-stacks \
+              --stack-name "$STACK_NAME" \
+              --region "$AWS_REGION" \
+              --query 'Stacks[0].StackStatus' \
+              --output text 2>/dev/null || echo "STACK_NOT_FOUND")
+
+            echo "[$(date -u +%H:%M:%S)] Stack status: $STACK_STATUS"
+
+            # Exit if stack reached a terminal state
+            for STATUS in $TERMINAL_STATUSES; do
+              if [[ "$STACK_STATUS" == "$STATUS" ]]; then
+                echo "Stack reached terminal state: $STACK_STATUS -- monitor exiting."
+                exit 0
+              fi
+            done
+
+            if [[ "$STACK_STATUS" == "STACK_NOT_FOUND" ]]; then
+              echo "Stack not found -- may have been deleted or never existed. Exiting."
+              exit 0
+            fi
+
+            # Fetch latest CloudFormation event timestamp
+            LATEST_EVENT_TS=$(aws cloudformation describe-stack-events \
+              --stack-name "$STACK_NAME" \
+              --region "$AWS_REGION" \
+              --query 'StackEvents[0].Timestamp' \
+              --output text 2>/dev/null || echo "")
+
+            if [[ -n "$LATEST_EVENT_TS" && "$LATEST_EVENT_TS" != "None" ]]; then
+              # Convert ISO8601 timestamp to epoch (supports both Linux and macOS date)
+              LATEST_EPOCH=$(date -u -d "$LATEST_EVENT_TS" +%s 2>/dev/null \
+                || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${LATEST_EVENT_TS%%.*}" +%s 2>/dev/null \
+                || echo "$LAST_EVENT_TIME")
+
+              if [[ "$LATEST_EPOCH" -gt "$LAST_EVENT_TIME" ]]; then
+                echo "New event at $LATEST_EVENT_TS -- resetting hang timer."
+                LAST_EVENT_TIME=$LATEST_EPOCH
+              fi
+            fi
+
+            # Check if hang threshold exceeded
+            NOW=$(date -u +%s)
+            SECONDS_SINCE_LAST_EVENT=$(( NOW - LAST_EVENT_TIME ))
+
+            if [[ "$SECONDS_SINCE_LAST_EVENT" -ge "$HANG_THRESHOLD_SECONDS" ]]; then
+              echo "No new events for ${SECONDS_SINCE_LAST_EVENT}s (threshold: ${HANG_THRESHOLD_SECONDS}s). Triggering AI analysis."
+              echo "AI_TRIGGER" > /tmp/ai_trigger
+              exit 0
+            fi
+
+            sleep "$POLL_INTERVAL_SECONDS"
+          done

--- a/.github/workflows/reusable-cdk-deploy-monitor.yml
+++ b/.github/workflows/reusable-cdk-deploy-monitor.yml
@@ -211,7 +211,7 @@ jobs:
               -d "$REQUEST_BODY" 2>/dev/null || echo '{}')
 
             AI_TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // "WAIT Could not reach AI model."' 2>/dev/null || echo "WAIT Could not parse AI response.")
-            VERDICT=$(echo "$AI_TEXT" | head -1 | grep -oE '^(CANCEL|WAIT)' || echo "WAIT")
+            VERDICT=$(echo "$AI_TEXT" | head -1 | tr '[:lower:]' '[:upper:]' | grep -oE '^(CANCEL|WAIT)' || echo "WAIT")
 
             echo "AI verdict: $VERDICT"
             echo "AI explanation: $AI_TEXT"

--- a/.github/workflows/reusable-cdk-deploy-monitor.yml
+++ b/.github/workflows/reusable-cdk-deploy-monitor.yml
@@ -45,6 +45,7 @@ jobs:
   monitor:
     name: Monitor CDK deploy (${{ inputs.stack_name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -126,6 +127,7 @@ jobs:
 
             if [[ "$SECONDS_SINCE_LAST_EVENT" -ge "$HANG_THRESHOLD_SECONDS" ]]; then
               echo "No new events for ${SECONDS_SINCE_LAST_EVENT}s (threshold: ${HANG_THRESHOLD_SECONDS}s). Triggering AI analysis."
+              echo "Last event timestamp: ${LATEST_EVENT_TS:-unknown}"
               echo "AI_TRIGGER" > /tmp/ai_trigger
               exit 0
             fi

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -130,3 +130,109 @@ Ensure the workflow environment has access to the OIDC-based credentials.
 Check that the AWS account ID secret (`TECHDOCS_AWS_ACCOUNT_ID` or the repo
 override `AWS_ACCOUNT_ID`) is set and non-empty, and that the IAM role trust
 policy allows the `geolonia` GitHub org.
+
+## CDK Deploy Monitor (`reusable-cdk-deploy-monitor.yml`)
+
+Runs as a parallel job alongside a CDK deploy to detect hanging CloudFormation stacks.
+When no new CloudFormation events appear for a configurable threshold, it fetches
+CloudWatch logs and asks the GitHub Models AI (GPT-4o) whether the deployment is stuck
+or just slow. The verdict is posted as a commit comment. If `auto_cancel` is enabled and
+the AI says CANCEL, the workflow calls `cancel-update-stack`, triggering a rollback and
+causing the deploy job to fail cleanly instead of timing out.
+
+### When to use it
+
+Add this to any repo that deploys CDK stacks via GitHub Actions and has experienced
+GH Actions timeouts due to hanging CloudFormation updates.
+
+### Required IAM permissions for `aws_role_arn`
+
+The OIDC role passed as `aws_role_arn` must include the `CdkDeployMonitor` permission
+bundle (defined in `geolonia-infra-cdk`):
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "cloudformation:DescribeStackEvents",
+    "cloudformation:DescribeStacks",
+    "cloudformation:CancelUpdateStack",
+    "logs:DescribeLogGroups",
+    "logs:DescribeLogStreams",
+    "logs:FilterLogEvents",
+    "logs:GetLogEvents"
+  ],
+  "Resource": "*"
+}
+```
+
+For repos using `geolonia-infra-cdk` to manage their deploy role, add
+`permissionBundles: ['CdkDeployMonitor']` to the role entry in the account config.
+
+### Example integration
+
+```yaml
+jobs:
+  deploy:
+    # ... your existing deploy job, unchanged
+
+  monitor:
+    uses: geolonia/.github/.github/workflows/reusable-cdk-deploy-monitor.yml@v1
+    with:
+      stack_name: MyAppStack
+      aws_region: ap-northeast-1
+      log_group_name: "MyAppStack-MyLogGroup"   # optional
+      hang_threshold_minutes: 10                 # optional, default: 10
+      auto_cancel: false                         # optional, default: false
+    secrets:
+      aws_role_arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/YOUR_DEPLOY_ROLE
+```
+
+Also add `pull-requests: write` to the calling workflow's top-level `permissions:` block
+so the monitor can post commit comments.
+
+### Input reference
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `stack_name` | string | required | CloudFormation stack name to monitor |
+| `aws_region` | string | required | AWS region |
+| `log_group_name` | string | `""` | CloudWatch log group name or prefix (leave empty to skip) |
+| `hang_threshold_minutes` | number | `10` | Minutes of silence before asking AI |
+| `poll_interval_seconds` | number | `120` | How often to poll (seconds) |
+| `auto_cancel` | boolean | `false` | If true, AI verdict of CANCEL triggers `cancel-update-stack` |
+
+### `auto_cancel` trade-offs
+
+| Setting | Behaviour |
+|---|---|
+| `false` (default) | Advisory mode: AI posts a comment but never cancels. Safe for initial rollout. |
+| `true` | Automatic: cancels the stack on AI verdict, stopping the timeout. Preferred once you trust the AI accuracy. |
+
+Start with `auto_cancel: false` to validate AI judgements over a few real deploys before enabling `true`.
+
+### Log sensitivity warning
+
+**Do not set `log_group_name`** if your application logs may contain secrets, credentials,
+PII, or other sensitive data. Log content is sent to the GitHub Models API (Azure-hosted
+OpenAI service) and is also visible in the commit comment. When in doubt, omit the input.
+
+### Troubleshooting
+
+**Monitor exits immediately without analysing:**
+The stack may have already reached a terminal state before the first poll. This is normal
+for fast deploys. Check the `Monitor stack` step log for the final status line.
+
+**AI analysis not firing:**
+Confirm `hang_threshold_minutes` is not set too high relative to your GH Actions job
+timeout. Check the `Monitor stack` step logs for `[HH:MM:SS] Stack status:` lines.
+
+**Commit comment not posted:**
+Ensure the calling workflow has `pull-requests: write` in its `permissions:` block.
+Without it, the GITHUB_TOKEN passed to the reusable workflow will lack the required scope.
+
+**`cancel-update-stack` returns an error:**
+The stack may have already reached a terminal state between the AI analysis and the
+cancel call. This is harmless. Check the commit comment for the error detail.
+The OIDC role must also have `cloudformation:CancelUpdateStack` -- verify the
+`CdkDeployMonitor` permission bundle is attached.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -188,8 +188,9 @@ jobs:
       aws_role_arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/YOUR_DEPLOY_ROLE
 ```
 
-Also add `pull-requests: write` to the calling workflow's top-level `permissions:` block
-so the monitor can post commit comments.
+Also add `contents: write` and `pull-requests: write` to the calling workflow's top-level
+`permissions:` block. The monitor uses the commit comments API (requires `contents: write`)
+and may annotate pull requests (requires `pull-requests: write`).
 
 ### Input reference
 
@@ -228,8 +229,9 @@ Confirm `hang_threshold_minutes` is not set too high relative to your GH Actions
 timeout. Check the `Monitor stack` step logs for `[HH:MM:SS] Stack status:` lines.
 
 **Commit comment not posted:**
-Ensure the calling workflow has `pull-requests: write` in its `permissions:` block.
-Without it, the GITHUB_TOKEN passed to the reusable workflow will lack the required scope.
+Ensure the calling workflow has `contents: write` in its `permissions:` block (commit
+comments require write access to repository contents). Also add `pull-requests: write`
+if you want AI verdicts to appear on pull request timelines.
 
 **`cancel-update-stack` returns an error:**
 The stack may have already reached a terminal state between the AI analysis and the

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -218,7 +218,7 @@ Start with `auto_cancel: false` to validate AI judgements over a few real deploy
 PII, or other sensitive data. Log content is sent to the GitHub Models API (Azure-hosted
 OpenAI service) and is also visible in the commit comment. When in doubt, omit the input.
 
-### Troubleshooting
+### Troubleshooting the deploy monitor
 
 **Monitor exits immediately without analysing:**
 The stack may have already reached a terminal state before the first poll. This is normal

--- a/workflow-templates/cdk-deploy-monitor.properties.json
+++ b/workflow-templates/cdk-deploy-monitor.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "CDK Deploy Monitor",
+  "description": "Detects hanging CloudFormation stack updates during CDK deploys. Uses GitHub Models AI to diagnose whether the deployment is stuck, posts a commit comment with the verdict, and optionally cancels the update.",
+  "iconName": "shield",
+  "categories": ["Deployment", "Monitoring"],
+  "filePatterns": [".github/workflows/deploy*.yml", ".github/workflows/*deploy*.yml"]
+}

--- a/workflow-templates/cdk-deploy-monitor.yml
+++ b/workflow-templates/cdk-deploy-monitor.yml
@@ -1,3 +1,4 @@
+# NOTE: This is a partial snippet -- paste the 'monitor' job into your existing deploy workflow file.
 # Add this `monitor` job alongside your existing `deploy` job.
 # Both jobs run in parallel automatically.
 #

--- a/workflow-templates/cdk-deploy-monitor.yml
+++ b/workflow-templates/cdk-deploy-monitor.yml
@@ -1,0 +1,21 @@
+# Add this `monitor` job alongside your existing `deploy` job.
+# Both jobs run in parallel automatically.
+#
+# Prerequisites:
+#   1. Set CDK_DEPLOY_ROLE_ARN secret in your repo (the same OIDC role used for CDK deploy,
+#      with CdkDeployMonitor permissions added -- see docs/workflows.md in geolonia/.github).
+#   2. Replace stack_name and aws_region with your values.
+
+jobs:
+  # ... your existing deploy job here ...
+
+  monitor:
+    uses: geolonia/.github/.github/workflows/reusable-cdk-deploy-monitor.yml@v1
+    with:
+      stack_name: MyAppStack        # CloudFormation stack name
+      aws_region: ap-northeast-1   # AWS region
+      # log_group_name: "MyAppStack-MyLogGroup*"  # Optional: CloudWatch log group prefix
+      # hang_threshold_minutes: 10                # Optional: default 10
+      # auto_cancel: false                        # Optional: set true to enable auto-cancel
+    secrets:
+      aws_role_arn: ${{ secrets.CDK_DEPLOY_ROLE_ARN }}

--- a/workflow-templates/cdk-deploy-monitor.yml
+++ b/workflow-templates/cdk-deploy-monitor.yml
@@ -6,6 +6,9 @@
 #   1. Set CDK_DEPLOY_ROLE_ARN secret in your repo (the same OIDC role used for CDK deploy,
 #      with CdkDeployMonitor permissions added -- see docs/workflows.md in geolonia/.github).
 #   2. Replace stack_name and aws_region with your values.
+#   3. Add these permissions to your workflow's top-level permissions block:
+#        contents: write      # required for commit comments
+#        pull-requests: write # required for PR annotations
 
 jobs:
   # ... your existing deploy job here ...


### PR DESCRIPTION
Closes #3, #4, #5, #6, #7, #8, #10. Part of #11.

## Summary

- Adds `reusable-cdk-deploy-monitor.yml` -- a reusable workflow that runs as a parallel job alongside any CDK deploy, polls CloudFormation events for hang detection, fetches CloudWatch logs, and asks GitHub Models (GPT-4o) whether to CANCEL or WAIT
- Adds `workflow-templates/cdk-deploy-monitor.yml` + `.properties.json` for the GitHub "New workflow" picker
- Updates `docs/workflows.md` with full TechDocs documentation (usage, IAM permissions, inputs, auto_cancel trade-offs, log sensitivity warning, troubleshooting)

Companion PRs needed:
- `geolonia-infra-cdk`: adds `CdkDeployMonitor` IAM permission bundle (already committed locally)
- `geolonia-backstage`: deploy workflow updated with monitor job (already committed locally)
- `geolonia-n8n`: deploy workflow updated with monitor job (already committed locally)

Design doc: https://github.com/geolonia/geolonia-operations/blob/main/docs/plans/2026-03-25-cdk-deploy-monitor-design.md

## Test plan

- [ ] actionlint passes on `reusable-cdk-deploy-monitor.yml` (verified)
- [ ] Trigger a deploy workflow on backstage or n8n and confirm the `monitor` job appears in parallel in the Actions UI
- [ ] To test hang detection: temporarily set `hang_threshold_minutes: 1` and `poll_interval_seconds: 30`, trigger a deploy, confirm AI analysis fires and a commit comment is posted after ~1 minute
- [ ] Restore `hang_threshold_minutes: 10` and `poll_interval_seconds: 120`
- [ ] Cut a `v1` tag from `main` after this PR merges so repos can pin to `@v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deployment monitoring workflow that detects stalled CloudFormation stack updates during deployments
  * Uses AI analysis of stack events and CloudWatch logs to determine if deployment is stuck or progressing slowly
  * Supports configurable silence thresholds and optional automatic cancellation of stuck updates
  * Includes documentation and workflow templates for easy adoption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->