### PR TITLE
Change 'Fixes' to 'Refs' in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Fixes #<issue_number>
+Refs #<issue_number>
 
 ## Summary
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-Refs #<issue_number>
-
 ## Summary
 
 <!-- Briefly describe your changes -->
@@ -8,3 +6,7 @@ Refs #<issue_number>
 
 - [ ] Tests added/updated
 - [ ] Docs updated
+
+## Related Issues
+
+<!-- fill all issues that is related to this PR -->


### PR DESCRIPTION
Fixes do not use "Fixes" in PR template

## Summary

In GitHub, if a pull request description contains keywords like "Fixes #xx", the referenced issue is automatically closed when the PR is merged.

This can cause problems when a single issue is addressed by multiple PRs, as the issue may be closed prematurely.

To avoid this, it would be better to use "Refs #xx" (or similar) by default, and only use "Fixes #xx" when the issue is fully resolved.

## Checklist (optional)

- [ ] Tests added/updated
- [ ] Docs updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request template with modified issue reference format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->