### PR TITLE
fix(release): mark latest release by semver instead of creation date

### DIFF
--- a/.github/workflows/reusable-release-auto-on-tag.yml
+++ b/.github/workflows/reusable-release-auto-on-tag.yml
@@ -103,7 +103,9 @@ jobs:
           if gh release view "$TAG" &>/dev/null; then
             echo "Release $TAG already exists, skipping"
           else
-            args=("$TAG" --title "$TAG")
+            # --latest=legacy lets GitHub pick the highest semver as "Latest"
+            # instead of defaulting to the most recently created release.
+            args=("$TAG" --title "$TAG" --latest=legacy)
             [[ "$GENERATE_NOTES" == "true" ]] && args+=(--generate-notes)
             [[ "$PRERELEASE"     == "true" ]] && args+=(--prerelease)
             gh release create "${args[@]}"

--- a/.github/workflows/reusable-release-auto-on-tag.yml
+++ b/.github/workflows/reusable-release-auto-on-tag.yml
@@ -103,12 +103,20 @@ jobs:
           if gh release view "$TAG" &>/dev/null; then
             echo "Release $TAG already exists, skipping"
           else
-            # --latest=legacy lets GitHub pick the highest semver as "Latest"
-            # instead of defaulting to the most recently created release.
-            args=("$TAG" --title "$TAG" --latest=legacy)
+            args=("$TAG" --title "$TAG")
             [[ "$GENERATE_NOTES" == "true" ]] && args+=(--generate-notes)
             [[ "$PRERELEASE"     == "true" ]] && args+=(--prerelease)
             gh release create "${args[@]}"
+            # gh release create's --latest flag is boolean-only; use the REST
+            # API to set make_latest=legacy so GitHub picks the highest semver
+            # as "Latest" instead of defaulting to the most recently created
+            # release.
+            if [[ "$PRERELEASE" != "true" ]]; then
+              gh api \
+                --method PATCH \
+                "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+                -f make_latest=legacy >/dev/null
+            fi
           fi
 
       - name: Generate GitHub App token

--- a/.github/workflows/reusable-release-auto-on-tag.yml
+++ b/.github/workflows/reusable-release-auto-on-tag.yml
@@ -112,9 +112,10 @@ jobs:
             # as "Latest" instead of defaulting to the most recently created
             # release.
             if [[ "$PRERELEASE" != "true" ]]; then
+              RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.id')
               gh api \
                 --method PATCH \
-                "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+                "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
                 -f make_latest=legacy >/dev/null
             fi
           fi


### PR DESCRIPTION
## Summary
`gh release create` without `--latest` defaults to marking the newly created release as "Latest". This caused `v1.49.3` in `geolonia-backstage` to get flagged as Latest even though `v2.2.1` is higher semver.

`--latest=legacy` tells GitHub to pick the highest semver.

## Test plan
- [ ] CodeRabbit review
- [ ] After merge, tag a new release in a consumer repo (e.g. `geolonia-backstage` v2.3.0) and confirm the Releases page shows v2.3.0 as Latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release creation process to refine how releases are marked as latest on GitHub during new release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->