### PR TITLE
fix: use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/reusable-release-auto-on-tag.yml
+++ b/.github/workflows/reusable-release-auto-on-tag.yml
@@ -124,7 +124,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
+          client-id: ${{ secrets.WORKFLOWS_CLIENT_ID }}
           private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
 
       - name: Use App token for pushes


### PR DESCRIPTION
## Summary
`actions/create-github-app-token@v3` deprecated `app-id` in favor of `client-id`. The deprecation warning was showing on every release workflow run.

Switches to the new org-level secret `WORKFLOWS_CLIENT_ID` (Client ID of the *Geolonia Workflows* GitHub App). `WORKFLOWS_APP_PRIVATE_KEY` is unchanged.

Precedent: same change was made in `geolonia-operations` (commit b0d7fac).

## Test plan
- [ ] CodeRabbit review
- [ ] After merge, tag a release and confirm the deprecation annotation no longer appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for the automated release process to use an enhanced authentication mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->