### PR TITLE
docs(tooling): add org-wide Backstage MCP server entry

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -11,3 +11,38 @@ This list covers tools used across Geolonia repositories.
 - OpenCode
 - Claude Code
 - Codex review
+
+## Org-wide MCP servers
+
+Geolonia operates a Backstage MCP server that exposes the software catalog
+(services, APIs, ownership, dependencies, lifecycle) as MCP tools. Agents
+can use it to answer cross-repo catalog questions without leaving the
+editor.
+
+- URL: `https://backstage.hub.geolonia.com/api/mcp-actions/v1/catalog-readonly`
+- Auth: per-user OAuth via your existing Backstage GitHub sign-in. No shared
+  token. The first MCP call opens a browser approval popup; once approved
+  the token is cached locally by your client.
+- Read-only by design. Mutating actions (registering or unregistering
+  entities) still go through the Backstage UI or `catalog-info.yaml` PRs.
+
+Claude Code setup:
+
+```bash
+claude mcp add --transport http geolonia-backstage \
+  https://backstage.hub.geolonia.com/api/mcp-actions/v1/catalog-readonly
+```
+
+Tools exposed:
+
+- `catalog.get-catalog-model-description`: markdown overview of catalog
+  kinds, annotations, relations.
+- `catalog.get-catalog-entity`: fetch a single entity by kind, namespace,
+  and name.
+- `catalog.query-catalog-entities`: predicate queries with full text,
+  sort, and pagination.
+- `catalog.validate-entity`: validate `catalog-info.yaml` contents.
+
+The server itself is implemented in `geolonia/geolonia-backstage` via the
+experimental `@backstage/plugin-mcp-actions-backend`. Filter syntax and
+auth model may change with upstream releases.


### PR DESCRIPTION
Final piece of [geolonia/geolonia-operations#41](https://github.com/geolonia/geolonia-operations/issues/41).

## What

Adds an "Org-wide MCP servers" section to \`docs/tooling.md\` describing the production Backstage MCP catalog server. New repositories will discover the endpoint through the existing \`agent-policy.md\` link to this file.

## Why org-wide

Per-repo AGENTS.md files in \`geolonia-operations\` and its five submodules already point to the longer setup section in the operations AGENTS.md. This org-level entry serves as the canonical short description for new repositories that haven't yet added a local pointer, and as the natural home alongside other recommended tooling.

Auth is per-user OAuth via the experimental Dynamic Client Registration flow, so no shared bearer token to distribute.

## Test plan

- [x] Markdown renders in GitHub preview
- [x] No em-dashes (per AGENTS.md working agreement)
- [ ] CodeRabbit pass