### PR TITLE
docs(tooling): point at consolidated Backstage MCP endpoint

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -14,23 +14,25 @@ This list covers tools used across Geolonia repositories.
 
 ## Org-wide MCP servers
 
-Geolonia operates a Backstage MCP server that exposes the software catalog
-(services, APIs, ownership, dependencies, lifecycle) as MCP tools. Agents
-can use it to answer cross-repo catalog questions without leaving the
-editor.
+Geolonia operates a single read-only Backstage MCP server that exposes the
+software catalog, the Scaffolder (read-only), and notifications as MCP
+tools. Agents can use it to answer cross-repo catalog questions, look up
+templates, and read notifications without leaving the editor.
 
-- URL: `https://backstage.hub.geolonia.com/api/mcp-actions/v1/catalog-readonly`
+- URL: `https://backstage.hub.geolonia.com/api/mcp-actions/v1/geolonia-backstage`
 - Auth: per-user OAuth via your existing Backstage GitHub sign-in. No shared
   token. The first MCP call opens a browser approval popup; once approved
   the token is cached locally by your client.
 - Read-only by design. Mutating actions (registering or unregistering
-  entities) still go through the Backstage UI or `catalog-info.yaml` PRs.
+  entities, executing Scaffolder templates) still go through the Backstage
+  UI or `catalog-info.yaml` PRs. Future writable actions will be exposed
+  under separate endpoints so they remain explicit opt-ins.
 
 Claude Code setup:
 
 ```bash
 claude mcp add --transport http geolonia-backstage \
-  https://backstage.hub.geolonia.com/api/mcp-actions/v1/catalog-readonly
+  https://backstage.hub.geolonia.com/api/mcp-actions/v1/geolonia-backstage
 ```
 
 Tools exposed:
@@ -42,6 +44,13 @@ Tools exposed:
 - `catalog.query-catalog-entities`: predicate queries with full text,
   sort, and pagination.
 - `catalog.validate-entity`: validate `catalog-info.yaml` contents.
+- `scaffolder.list-scaffolder-actions`: list installed Scaffolder actions.
+- `scaffolder.list-scaffolder-tasks`: list template tasks.
+- `scaffolder.get-scaffolder-task-logs`: fetch log events for a task.
+- `scaffolder.dry-run-template`: validate a template without making
+  changes.
+- `notifications.get-notifications`: fetch the signed-in user's
+  notifications.
 
 The server itself is implemented in `geolonia/geolonia-backstage` via the
 experimental `@backstage/plugin-mcp-actions-backend`. Filter syntax and


### PR DESCRIPTION
Refresh of \`docs/tooling.md\` to match the URL change shipped in [geolonia/geolonia-backstage#160](https://github.com/geolonia/geolonia-backstage/pull/160) (just merged, currently deploying as v2.9.2).

## Changes

- Single endpoint \`/api/mcp-actions/v1/geolonia-backstage\` instead of three.
- Tool list expanded to cover catalog + scaffolder (read-only) + notifications in one place.
- Note that writable actions will land at separate endpoints.

## Test plan

- [x] Markdown renders in GitHub preview
- [x] No em-dashes (per AGENTS.md working agreement)
- [ ] CodeRabbit pass

Refs geolonia/geolonia-operations#40.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for the unified MCP server, now supporting Scaffolder templates and user notifications alongside catalog tools.
  * Refreshed MCP endpoint configuration and the corresponding setup command for easier integration.
  * Clarified read-only behavior and how Scaffolder features are accessed through the Backstage UI or pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->