### PR TITLE
docs(tooling): minimise public detail about the internal MCP server

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -14,44 +14,11 @@ This list covers tools used across Geolonia repositories.
 
 ## Org-wide MCP servers
 
-Geolonia operates a single read-only Backstage MCP server that exposes the
-software catalog, the Scaffolder (read-only), and notifications as MCP
-tools. Agents can use it to answer cross-repo catalog questions, look up
-templates, and read notifications without leaving the editor.
+Geolonia runs an internal Backstage MCP server that AI assistants
+(Claude Code, Cursor, etc.) can use to answer questions about and act on
+our software catalog.
 
-- URL: `https://backstage.hub.geolonia.com/api/mcp-actions/v1/geolonia-backstage`
-- Auth: per-user OAuth via your existing Backstage GitHub sign-in. No shared
-  token. The first MCP call opens a browser approval popup; once approved
-  the token is cached locally by your client.
-- Read-only by design. Mutating actions (registering or unregistering
-  entities, executing Scaffolder templates) still go through the Backstage
-  UI or `catalog-info.yaml` PRs. Future writable actions will be exposed
-  under separate endpoints so they remain explicit opt-ins.
-
-Claude Code setup:
-
-```bash
-claude mcp add --transport http geolonia-backstage \
-  https://backstage.hub.geolonia.com/api/mcp-actions/v1/geolonia-backstage
-```
-
-Tools exposed:
-
-- `catalog.get-catalog-model-description`: markdown overview of catalog
-  kinds, annotations, relations.
-- `catalog.get-catalog-entity`: fetch a single entity by kind, namespace,
-  and name.
-- `catalog.query-catalog-entities`: predicate queries with full text,
-  sort, and pagination.
-- `catalog.validate-entity`: validate `catalog-info.yaml` contents.
-- `scaffolder.list-scaffolder-actions`: list installed Scaffolder actions.
-- `scaffolder.list-scaffolder-tasks`: list template tasks.
-- `scaffolder.get-scaffolder-task-logs`: fetch log events for a task.
-- `scaffolder.dry-run-template`: validate a template without making
-  changes.
-- `notifications.get-notifications`: fetch the signed-in user's
-  notifications.
-
-The server itself is implemented in `geolonia/geolonia-backstage` via the
-experimental `@backstage/plugin-mcp-actions-backend`. Filter syntax and
-auth model may change with upstream releases.
+Endpoint, auth flow, available tools, and setup instructions live in the
+internal Backstage TechDocs site (under "Using Backstage > MCP Server")
+and in repository-level `AGENTS.md` files. Access is gated by per-user
+OAuth against the Geolonia GitHub organization.


### PR DESCRIPTION
This repository is public; \`docs/tooling.md\` was leaking more than necessary about an internal service.

## Removed from the public doc

- The production MCP endpoint URL (\`backstage.hub.geolonia.com/api/mcp-actions/v1/geolonia-backstage\`).
- The full list of tools we expose, including the mutating ones (register / unregister / execute-template).
- The Claude Code setup command.
- The upstream plugin name (\`@backstage/plugin-mcp-actions-backend\`).

## What stays

A one-paragraph existence claim ("we run an internal Backstage MCP server") and a pointer to the internal TechDocs + repo \`AGENTS.md\` files where the actual setup details live.

## Threat model

Auth still gates every call (per-user OAuth against the Geolonia GitHub org), so the previous public detail was not directly exploitable. But it was unnecessary capability disclosure that anyone scanning the org could read. Internal users get the same information from internal sources.

## Test plan

- [x] Markdown renders cleanly
- [x] No em-dashes (per AGENTS.md working agreement)
- [ ] CodeRabbit pass

Refs geolonia/geolonia-operations#40.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP server documentation to redirect readers to internal resources for configuration, authentication, and tooling specifics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->