### PR TITLE
chore: ignore Serena local project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Serena (local, personal)
+.serena/


### PR DESCRIPTION
## Summary
- Ignore `.serena/` so Serena per-project local cache, indexing, and machine-local config do not get committed.

## Why
Per the geolonia-operations Serena setup pattern, each submodule is registered as its own Serena project (own LSP scope, clean symbol cache). The `.serena/` directory holds machine-local state (cache, `project.local.yml`) that varies per developer.

## Test plan
- [x] `.gitignore` updated, no other files affected
- [ ] CodeRabbit review