### PR TITLE
chore(coderabbit): tune up the shared review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,7 +8,16 @@ reviews:
   collapse_walkthrough: false
   auto_review:
     enabled: true
-    auto_incremental_review: false
+    auto_incremental_review: true
+  path_filters:
+    - "!**/pnpm-lock.yaml"
+    - "!**/yarn.lock"
+    - "!**/package-lock.json"
+    - "!**/dist/**"
+    - "!**/cdk.out/**"
+    - "!**/coverage/**"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
   tools:
     shellcheck:
       enabled: true
@@ -20,5 +29,9 @@ reviews:
       enabled: true
       enabled_only: false
       level: default
+    markdownlint:
+      enabled: true
+    hadolint:
+      enabled: true
 chat:
   auto_reply: true


### PR DESCRIPTION
## Summary

Four targeted improvements to the canonical `.coderabbit.yaml` that all Geolonia repos will inherit via `remote_config`:

1. **`auto_incremental_review: true`** so each push to a PR auto-triggers a re-review. Removes the manual `@coderabbitai review` comment after every fix.
2. **`reviews.path_filters`** added to skip lock files, `dist/`, `cdk.out/`, `coverage/`, and minified assets. Saves CodeRabbit from reviewing generated content.
3. **`markdownlint`** enabled. Every Geolonia repo has a `docs/` TechDocs tree and we author markdown directly in PRs and issues.
4. **`hadolint`** enabled. Dockerfiles ship in `geolonia-datastore`, `geolonia-n8n`, and `geolonia-sitestore`.

## Context

Part of the rollout tracked in geolonia/geolonia-operations#54. Once this lands, 9 other Geolonia repos get tiny pointer files referencing this canonical config via `remote_config:`, eliminating the duplicated `.coderabbit.yaml` files currently scattered across the org.

## Test plan

* [x] YAML parses (verified locally)
* [ ] CodeRabbit picks up the new settings on this PR itself (auto_incremental_review, the new tools)
* [ ] CodeRabbit review

Refs geolonia/geolonia-operations#54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled incremental code reviews to provide faster feedback on changes
  * Configured file exclusions to skip processing of dependencies, generated files, and minified assets
  * Activated markdown and Docker linting tools to enhance code quality checks across projects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->