### PR TITLE
chore: track Serena project config + memories (public-safe)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-# Serena (local, personal)
-.serena/
+# Serena - track .serena/project.yml + memories/ so teammates share project
+# config and onboarding context. The inner .serena/.gitignore excludes the
+# local-only bits (cache/ + project.local.yml).

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/agent_policy_summary.md
+++ b/.serena/memories/agent_policy_summary.md
@@ -1,0 +1,47 @@
+# Org-wide agent policy summary
+
+The authoritative document is `docs/agent-policy.md` in this repo. Every
+Geolonia repo's `AGENTS.md` references it. Repo-specific rules may extend
+it but should not conflict with it.
+
+Quick summary so future sessions can decide whether to read the full doc:
+
+## Issue-first workflow (org-wide rule)
+
+- **Required** for feature/bugfix work that affects user-facing
+  behaviour or touches multiple files.
+- **Optional** for docs, typos, and small single-file refactors.
+- Branch naming: `issue-<n>-<slug>` from `main`. (Note: this differs from
+  the `chore/<topic>` / `feat/<topic>` patterns used in many submodules -
+  the org policy is more flexible; submodule-specific patterns win in
+  practice.)
+- Manual merge after checks pass. No auto-merge.
+
+This is the org-wide source of the "issue-first" pattern that the global
+memory `global/issue-first-pr-workflow` builds on.
+
+## Code reviews
+
+- CodeRabbit reviews every PR within minutes. Wait for it before
+  requesting a human reviewer.
+- Address every CodeRabbit comment. Resolve each thread after applying
+  the fix or replying with a rationale for declining.
+- Don't merge until: (1) CI passes, (2) all CodeRabbit blocking comments
+  are resolved, (3) at least one human reviewer has approved.
+
+## Team communication
+
+- **Don't use Slack** for ops requests / escalations. File a GitHub issue
+  in the relevant repo and assign it. Slack is informal-only.
+
+## Safety / hygiene
+
+- Never commit secrets or private keys.
+- Avoid destructive `git` commands unless explicitly requested.
+- Keep changes minimal and aligned with existing patterns.
+
+## Related org docs
+
+- `docs/context-maintenance.md`
+- `docs/roadmap-workflow.md`
+- `docs/tooling.md`

--- a/.serena/memories/code_style.md
+++ b/.serena/memories/code_style.md
@@ -16,7 +16,9 @@ Repo is markdown + YAML. The hard rules are short.
 
 ## **No em-dashes** (org-wide rule)
 
-The repo's `AGENTS.md` explicitly states: **"Must not use long dash `-`"**.
+The repo's `AGENTS.md` forbids the em-dash character (Unicode
+codepoint U+2014, the long dash that some editors auto-substitute
+for `--`).
 
 Applies to:
 
@@ -28,10 +30,12 @@ Applies to:
 
 Use a hyphen `-` or rephrase the sentence instead. This rule appears
 to be unique to this repo (other Geolonia repos don't enforce it), so
-when working **here** specifically, run a final check before pushing:
+when working **here** specifically, run a final check before pushing.
+Bash `$'...'` expansion materialises the hex bytes before grep sees
+them, so this works on both BSD (macOS) and GNU grep:
 
 ```sh
-git diff --cached | grep -E '\xe2\x80\x94' && echo "FAIL: em-dash present" || echo "OK"
+git diff --cached | grep $'\xe2\x80\x94' && echo "FAIL: U+2014 present" || echo "OK"
 ```
 
 ## YAML

--- a/.serena/memories/code_style.md
+++ b/.serena/memories/code_style.md
@@ -1,0 +1,67 @@
+# Code style and conventions
+
+Repo is markdown + YAML. The hard rules are short.
+
+## Markdown
+
+- Configured by `.markdownlint.json`:
+  - `MD033: false` - inline HTML allowed (used in some templates)
+  - `MD041: false` - first-line H1 not required (some files start with
+    intro paragraphs)
+- All other markdownlint defaults apply: ATX headings, fenced code
+  blocks, sentence-case headings, etc.
+- File encoding: UTF-8 (per `.editorconfig`).
+- Line endings: LF.
+- Trim trailing whitespace; final newline.
+
+## **No em-dashes** (org-wide rule)
+
+The repo's `AGENTS.md` explicitly states: **"Must not use long dash `-`"**.
+
+Applies to:
+
+- Markdown files (docs/, profile/, root .md files)
+- YAML descriptions and comments
+- Commit messages
+- PR titles and bodies
+- Issue bodies and comments
+
+Use a hyphen `-` or rephrase the sentence instead. This rule appears
+to be unique to this repo (other Geolonia repos don't enforce it), so
+when working **here** specifically, run a final check before pushing:
+
+```sh
+git diff --cached | grep -E '\xe2\x80\x94' && echo "FAIL: em-dash present" || echo "OK"
+```
+
+## YAML
+
+- 2-space indent.
+- Lowercase boolean values (`true` / `false`).
+- Quote string values that contain special characters or could be
+  misparsed as booleans / numbers (e.g. version-like strings).
+
+## Workflow templates (`workflow-templates/*.yml`)
+
+- Keep `<name>.yml` and `<name>.properties.json` consistent - the
+  `.properties.json` controls what shows up in GitHub's "New workflow"
+  picker.
+- Templates should reference reusable workflows by **tag**
+  (`@v1`, `@v2`), not by `@main` and not by SHA. See the
+  `reusable_workflows` memory.
+
+## Commit and PR text
+
+- Conventional-commit prefixes: `chore:`, `feat:`, `fix:`, `docs:`,
+  `test:`. Match what's already in `git log`.
+- PR title under 70 chars.
+- PR body follows the org template (`.github/pull_request_template.md`)
+  - Summary, link to issue (`Fixes #N` or `Refs #N`), test plan.
+
+## Prose
+
+- English for all docs except where Japanese parallel text already
+  exists (e.g. `profile/README.md`). Keep both languages in sync when
+  one changes.
+- `languagetool` is enabled in CodeRabbit at default level - keeps
+  prose tight without being picky.

--- a/.serena/memories/community_health_and_templates.md
+++ b/.serena/memories/community_health_and_templates.md
@@ -1,0 +1,42 @@
+# Community health files and templates
+
+GitHub auto-applies these to every Geolonia repo that doesn't override
+them locally. Touching them affects the whole org - treat as a
+higher-stakes change.
+
+## Community health (auto-inherited)
+
+| File | Effect |
+|---|---|
+| `CODE_OF_CONDUCT.md` | Linked from any repo's "Insights → Community" tab; based on Contributor Covenant. |
+| `CONTRIBUTING.md` | Shown on PR creation; documents contribution flow + review expectations. |
+| `SUPPORT.md` | Linked from any repo's "Issues → Get help" prompt. |
+| `SECURITY.md` | Linked from any repo's "Security" tab; vulnerability reporting process. |
+| `LICENSE` | Default for new repos until they add their own. |
+
+## Issue / PR templates (auto-inherited)
+
+- `.github/ISSUE_TEMPLATE/bug_report.yml` - labels new issues with `bug`.
+- `.github/ISSUE_TEMPLATE/feature_request.yml` - labels new issues with `enhancement`.
+- `.github/ISSUE_TEMPLATE/config.yml` - controls "Open a blank issue" link
+  and points to commercial support.
+- `.github/pull_request_template.md` - prompts for `Fixes #N` linkage,
+  summary, optional tests/docs checklist.
+
+## Maintenance rules
+
+- Update this repo first when a guideline changes - every project picks
+  it up automatically.
+- Keep contact emails / links current in the policy files.
+- **Never include repo-specific information** here. If a single project
+  needs a different policy, use a per-repo override in that repo
+  (commit a local file with the same name).
+- **No sensitive information** ever - repo is and must remain public.
+
+## Override behaviour
+
+A repo can override any inherited file by committing a file at the same
+path locally. GitHub picks the closest one (repo-local first,
+`.github` repo second). This means accidentally creating an
+`.github/pull_request_template.md` in another repo silently shadows the
+org default - worth checking when a repo's PR form looks "wrong."

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,41 @@
+# Project overview
+
+**Name**: `geolonia/.github`
+**Owner**: `group:geolonia/operations`
+**Visibility**: **Public - must remain public**. GitHub gives this repo
+special treatment (see "What lives here") *only* when it is named `.github`
+and is publicly accessible.
+
+## Purpose
+
+Single source of truth for organization-wide GitHub assets and policies:
+
+- Org profile content shown on `https://github.com/geolonia` (`profile/`)
+- Community health files: `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`,
+  `SUPPORT.md`, `SECURITY.md`, `LICENSE`
+- Issue and PR templates (`.github/ISSUE_TEMPLATE/`, `.github/pull_request_template.md`)
+- Reusable GitHub Actions workflows (in `.github/workflows/`) and their
+  template wrappers (in `workflow-templates/`)
+- Org-wide agent policy (`docs/agent-policy.md`) - referenced by every
+  Geolonia repo's `AGENTS.md`
+- Canonical CodeRabbit configuration (`.coderabbit.yaml`) - referenced by
+  every other Geolonia repo via `remote_config:`. See the dedicated
+  `shared_coderabbit_config` memory.
+
+## Critical constraints
+
+- **Public-only content**: never commit secrets, internal hostnames,
+  customer data, references to private repos, or anything that would
+  leak by being world-readable. See the dedicated
+  `public_repo_hygiene` memory for the do-not-include checklist.
+- **No em-dashes in any commit message, PR body, or markdown**
+  (per this repo's `AGENTS.md`).
+- **Edits propagate org-wide**: a change here can affect every Geolonia
+  repo's PR/issue forms, default templates, and CodeRabbit settings.
+  Treat changes here as higher-stakes than typical repo edits.
+
+## Authoritative agent guidance
+
+- This repo's `AGENTS.md` (root) - repo-local rules.
+- `docs/agent-policy.md` (this repo) - the org-wide policy that every
+  other Geolonia repo's `AGENTS.md` defers to.

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -1,6 +1,6 @@
 # Project structure
 
-```
+```text
 .
 ├── profile/
 │   └── README.md                         Org profile shown on github.com/geolonia

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -1,0 +1,68 @@
+# Project structure
+
+```
+.
+├── profile/
+│   └── README.md                         Org profile shown on github.com/geolonia
+├── docs/                                 TechDocs source (MkDocs)
+│   ├── index.md
+│   ├── agent-policy.md                   Org-wide AI agent policy
+│   ├── community-health.md
+│   ├── context-maintenance.md
+│   ├── profile.md
+│   ├── roadmap-workflow.md
+│   ├── tooling.md
+│   └── workflows.md                      How the reusable workflows pattern works
+├── workflow-templates/                   Templates shown in GitHub's "New workflow" UI
+│   ├── publish-techdocs.yml
+│   ├── publish-techdocs.properties.json
+│   ├── cdk-deploy-monitor.yml
+│   ├── cdk-deploy-monitor.properties.json
+│   ├── release-auto-on-tag.yml
+│   ├── release-auto-on-tag.properties.json
+│   ├── sync-team-access.yml
+│   ├── sync-team-access.properties.json
+│   └── CODEOWNERS
+├── .github/
+│   ├── workflows/
+│   │   ├── publish-techdocs.yml          This repo's own TechDocs publish entry
+│   │   ├── release-auto-on-tag.yml       This repo's own release entry
+│   │   ├── reusable-backstage-techdocs.yml      Logic - called by other repos
+│   │   ├── reusable-cdk-deploy-monitor.yml      Logic - called by other repos
+│   │   ├── reusable-release-auto-on-tag.yml     Logic - called by other repos
+│   │   └── reusable-sync-team-access.yml        Logic - called by other repos
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug_report.yml
+│   │   ├── feature_request.yml
+│   │   └── config.yml
+│   ├── pull_request_template.md
+│   └── CODEOWNERS                        This repo's CODEOWNERS
+├── CODE_OF_CONDUCT.md                    Org-wide community health files -
+├── CONTRIBUTING.md                          inherited by every Geolonia repo that
+├── SUPPORT.md                               does not override locally
+├── SECURITY.md
+├── LICENSE
+├── README.md
+├── AGENTS.md                             Repo-local agent guidance
+├── CLAUDE.md                             Points at AGENTS.md
+├── catalog-info.yaml                     Backstage entity
+├── .coderabbit.yaml                      CANONICAL source for the org -
+│                                            referenced via remote_config: by
+│                                            every other Geolonia repo
+├── .markdownlint.json
+├── .editorconfig
+└── mkdocs.yml                            TechDocs build config
+```
+
+## Two locations for workflows - the key idea
+
+GitHub's "New workflow" picker reads `workflow-templates/` (and its
+`.properties.json` siblings). The actual reusable logic lives in
+`.github/workflows/reusable-*.yml`. Templates in `workflow-templates/`
+point at tagged versions (e.g. `@v1`) of the reusable workflows so
+consumers pin a stable version. See the `reusable_workflows` memory.
+
+## Build artefacts and ignored paths
+
+This is a documentation/templates repo - no build artefacts. `.serena/`
+is gitignored; the `.gitignore` keeps the tree minimal.

--- a/.serena/memories/public_repo_hygiene.md
+++ b/.serena/memories/public_repo_hygiene.md
@@ -1,0 +1,104 @@
+# Public-repo hygiene
+
+**This repo (`geolonia/.github`) is public, and must remain public** for
+GitHub's `.github`-repo special handling to work. Anything committed
+here (code, docs, memories, workflows, templates) is world-readable
+forever.
+
+This memory codifies what must **not** appear in any change to this
+repo, including in `.serena/memories/` files now that they are tracked.
+
+## Do not include
+
+- **Secrets** of any kind: API tokens, deploy keys, passwords, signed
+  URLs, `op://` references that resolve to private values, AWS access
+  keys, GitHub PATs.
+- **AWS account IDs** (the 12-digit numbers), **ARNs that include
+  account IDs**, **IAM role names** scoped to specific accounts,
+  internal account aliases.
+- **Internal hostnames or URLs**: any private subdomain, internal
+  Backstage instance URLs, bastion / VPN hostnames, private S3
+  bucket names.
+- **References to private repos**:
+  - Names of any sibling repo that is not itself public. Even an
+    incidental mention confirms the repo exists.
+  - Issue / PR numbers in private repos (`<org>/<private-repo>#NNN`)
+    - these confirm the repo exists and reveal activity-level
+    metadata.
+  - File paths that imply internal workspace structure (parent
+    submodule names, monorepo layout, etc.).
+- **Customer data**: names, email addresses, support-ticket numbers,
+  domains belonging to customers.
+- **Staff personal data**: individual email addresses, phone numbers,
+  Slack handles (group aliases like `group:geolonia/operations` are
+  fine - they are already published in the org policy).
+- **Internal-only opinions or critiques** of people, vendors, or
+  partners.
+
+## Allowed and useful
+
+- Public GitHub URLs (`https://github.com/geolonia/...`) - but only
+  for repos that are themselves public.
+- Public org policy documents and their links
+  (`docs/agent-policy.md`, etc.).
+- Workflow and action names (the names themselves, not their secret
+  values).
+- Names of org secrets / variables (e.g. `TECHDOCS_AWS_ACCOUNT_ID` is
+  fine as a label; its value is not).
+- Patterns and conventions: PR / commit naming, branch strategies,
+  code-style rules, markdownlint settings.
+- Generic "how this org works" documentation - that is the whole point
+  of this repo.
+
+## When in doubt
+
+- Rephrase to describe the **pattern** instead of the specific internal
+  artifact. E.g. "tracked via an issue in our operations repo" rather
+  than naming the repo and issue number.
+- Strip cross-repo issue / PR links that point at private repos.
+- Keep self-references to this very repo (`geolonia/.github#NN`) -
+  those are public.
+- If a sentence requires private context to make sense, the right move
+  is usually to delete the sentence, not paraphrase it.
+- Avoid naming private artifacts even in examples or grep patterns. A
+  literal example string is a published string, regardless of the
+  surrounding sentence saying "do not include this."
+
+## Verification before opening a PR
+
+Build a local grep against the names of repos, domains, and workspace
+paths your org keeps private. Keep the pattern in a personal note or
+shell function - **do not commit the pattern itself to this repo**, or
+the published file becomes a directory of the very things it bans.
+
+Sketch (replace each bracketed placeholder with the literal value you
+want to catch):
+
+```sh
+# Private-repo / internal-path references in the staged diff:
+git diff --cached | grep -E '<private-repo-name>|<workspace-path>|@<staff-domain>'
+
+# Likely secrets:
+git diff --cached | grep -iE 'secret|password|token|api[-_]?key|AKIA[0-9A-Z]{16}'
+
+# AWS account IDs (12-digit numbers - inspect each hit in context):
+git diff --cached | grep -E '\b[0-9]{12}\b'
+```
+
+A hit is not always a leak (the word "secret" appears in this very
+memory), but every match deserves a deliberate look. See
+`task_completion_checklist` step 4 for the same check in the standard
+PR ritual.
+
+## If a leak has already shipped
+
+Treat anything previously committed to a public repo as compromised,
+even if you delete it later. Git history preserves the value, and
+crawlers / forks may have already cached it. Steps:
+
+1. **Rotate** the secret / credential immediately.
+2. Remove the value from the current tree and commit.
+3. Decide whether `git filter-repo` history rewrite is worth the
+   downstream pain (forks, clones, open PRs). For most non-credential
+   leaks - e.g. a private repo name mentioned in a memory - rotation
+   is not relevant and a forward fix is enough.

--- a/.serena/memories/reusable_workflows.md
+++ b/.serena/memories/reusable_workflows.md
@@ -1,0 +1,74 @@
+# Reusable GitHub Actions workflows
+
+This repo hosts org-wide reusable workflows. The pattern uses **two
+locations** in this repo plus a **tag-pinning convention** in callers.
+
+## The three roles
+
+| Role | Path | Purpose |
+|---|---|---|
+| **Template** | `workflow-templates/<name>.yml` + `<name>.properties.json` | Shown in GitHub's "New workflow" picker. Points at a tagged reusable workflow. |
+| **Entrypoint** | `.github/workflows/<name>.yml` | This repo's own use of the workflow (push/tag triggers). Forwards to the reusable workflow with defaults. |
+| **Reusable** | `.github/workflows/reusable-<name>.yml` | The actual logic. Callable from any repo via `uses: geolonia/.github/.github/workflows/reusable-<name>.yml@<tag>`. |
+
+## Currently maintained workflows
+
+- **`publish-techdocs`** - TechDocs publish on `docs/**` or `mkdocs.yml`
+  changes. Uses OIDC for AWS, with `TECHDOCS_AWS_ACCOUNT_ID` org secret
+  by default; per-repo `AWS_ACCOUNT_ID` override supported.
+- **`release-auto-on-tag`** - semver-tag-triggered releases (`v*.*.*`).
+  Optional inputs control prereleases, release notes, custom regex.
+- **`cdk-deploy-monitor`** - runs alongside a CDK deploy job, polls
+  CloudFormation/CloudWatch/ECS, asks GitHub Models (GPT-4o) whether the
+  deploy is hung, optionally cancels on CANCEL verdict. Requires
+  `CdkDeployMonitor` IAM permission bundle and `models: read` permission
+  in the calling workflow + every parent in the call chain.
+- **`sync-team-access`** - keeps GitHub team-to-repo access in sync.
+
+## Caller-side conventions
+
+Consumers should pin to a tag, not a SHA, not `@main`:
+
+```yaml
+jobs:
+  publish:
+    uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@v1
+    secrets: inherit
+```
+
+## Updating a reusable workflow
+
+When making **non-breaking** changes:
+
+1. Edit `.github/workflows/reusable-<name>.yml`.
+2. Open a PR. Wait for CodeRabbit + human approval.
+3. Merge to `main`.
+4. Move the `v1` tag forward (or whatever major tag is active):
+   ```sh
+   git tag -f v1
+   git push -f origin v1
+   ```
+
+When making **breaking** changes:
+
+1. Cut a new major tag (`v2`, `v3`, …) so consumers upgrade on their own
+   schedule.
+2. Update `workflow-templates/<name>.yml` to reference the new tag - but
+   only after enough consumers have migrated, otherwise new "New workflow"
+   selections will land on the latest tag and consumers expecting `v1`
+   stay on `v1`.
+3. Document the breaking change in a release note on the new tag.
+
+Always keep `workflow-templates/<name>.properties.json` in sync with the
+YAML so the picker shows accurate names/descriptions.
+
+## Common troubleshooting
+
+- **`Could not find reusable workflow`** - caller is pinned to a tag that
+  doesn't exist (or was deleted). Check
+  `gh api repos/geolonia/.github/git/refs/tags --jq '.[].ref'`.
+- **`Input required and not supplied`** for AWS account ID - confirm the
+  org-level `TECHDOCS_AWS_ACCOUNT_ID` secret is visible to the calling
+  repo, or the per-repo `AWS_ACCOUNT_ID` override is set.
+- **CDK deploy monitor doesn't post comments** - needs `contents: write`
+  + `models: read` on the **caller's** top-level `permissions:` block.

--- a/.serena/memories/reusable_workflows.md
+++ b/.serena/memories/reusable_workflows.md
@@ -16,6 +16,12 @@ locations** in this repo plus a **tag-pinning convention** in callers.
 - **`publish-techdocs`** - TechDocs publish on `docs/**` or `mkdocs.yml`
   changes. Uses OIDC for AWS, with `TECHDOCS_AWS_ACCOUNT_ID` org secret
   by default; per-repo `AWS_ACCOUNT_ID` override supported.
+  **Naming asymmetry**: the template + entrypoint pair are
+  `publish-techdocs.yml`, but the reusable file is
+  `reusable-backstage-techdocs.yml`, not `reusable-publish-techdocs.yml`
+  as the convention in the table above would predict. Consumers `uses:`
+  the reusable filename, so any reference must spell out
+  `reusable-backstage-techdocs.yml`.
 - **`release-auto-on-tag`** - semver-tag-triggered releases (`v*.*.*`).
   Optional inputs control prereleases, release notes, custom regex.
 - **`cdk-deploy-monitor`** - runs alongside a CDK deploy job, polls

--- a/.serena/memories/reusable_workflows.md
+++ b/.serena/memories/reusable_workflows.md
@@ -44,6 +44,7 @@ When making **non-breaking** changes:
 2. Open a PR. Wait for CodeRabbit + human approval.
 3. Merge to `main`.
 4. Move the `v1` tag forward (or whatever major tag is active):
+
    ```sh
    git tag -f v1
    git push -f origin v1

--- a/.serena/memories/shared_coderabbit_config.md
+++ b/.serena/memories/shared_coderabbit_config.md
@@ -1,0 +1,47 @@
+# Shared CodeRabbit config - this repo is the canonical source
+
+Every Geolonia repo's CodeRabbit review settings come from
+[`.coderabbit.yaml`](../.coderabbit.yaml) in **this repo**. Other repos
+contain only a 2-line pointer:
+
+```yaml
+remote_config:
+  url: https://raw.githubusercontent.com/geolonia/.github/main/.coderabbit.yaml
+```
+
+## Implications when editing `.coderabbit.yaml` here
+
+- **Effect is org-wide and immediate.** CodeRabbit fetches the URL at
+  review time, so the next PR opened in any Geolonia repo uses the new
+  config. There is no per-repo bump needed.
+- **Don't add repo-specific settings here** (e.g. paths only meaningful
+  to one repo). If a repo needs different rules, it drops the pointer
+  and writes its own full `.coderabbit.yaml`.
+- **No secrets.** The file is publicly fetchable by design.
+- **Test impact carefully.** A bad change here breaks reviews everywhere
+  on the next PR. Prefer small, well-justified changes; revert quickly
+  if anything looks off.
+
+## What it currently configures
+
+- `language: en-US` - English reviews, no Japanese fallback.
+- `reviews.profile: assertive`
+- `reviews.auto_review.enabled: true` + `auto_incremental_review: true`
+  (every push auto-retriggers).
+- `reviews.path_filters` - skips `pnpm-lock.yaml`, `yarn.lock`,
+  `package-lock.json`, `dist/`, `cdk.out/`, `coverage/`, `*.min.{js,css}`.
+- `reviews.tools` - shellcheck, yamllint, actionlint, languagetool,
+  markdownlint, hadolint.
+- `chat.auto_reply: true`.
+
+## Why not the dedicated `coderabbit` repo?
+
+CodeRabbit's "Central Configuration" feature is hardcoded to a repo
+named `coderabbit`. We chose `.github` over creating a new repo because
+the file already lived here, no Backstage scaffolder run is needed, and
+the trade-off (each new Geolonia repo has to add the 2-line pointer
+explicitly, vs. auto-applied via a `coderabbit` repo) is acceptable.
+
+The "shared configuration is not recommended" warning in the CodeRabbit
+docs concerns secret exposure, which doesn't apply here - our shared
+config is purely review-tool toggles.

--- a/.serena/memories/shared_coderabbit_config.md
+++ b/.serena/memories/shared_coderabbit_config.md
@@ -1,7 +1,7 @@
 # Shared CodeRabbit config - this repo is the canonical source
 
 Every Geolonia repo's CodeRabbit review settings come from
-[`.coderabbit.yaml`](../.coderabbit.yaml) in **this repo**. Other repos
+[`.coderabbit.yaml`](../../.coderabbit.yaml) in **this repo**. Other repos
 contain only a 2-line pointer:
 
 ```yaml

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,97 @@
+# Suggested commands
+
+This is a docs/templates repo - no test runner, no build pipeline. Most
+operations are `git` + `gh` + a markdown linter.
+
+## Core workflow
+
+```sh
+# Branch from main
+git checkout -b chore/<topic>          # or issue-<n>-<slug> per agent-policy.md
+
+# Push and open PR
+git push -u origin <branch>
+gh pr create --base main --title "..." --body "..."
+
+# Watch CodeRabbit + checks
+gh pr checks <num> --watch
+gh pr view <num> --json reviews,comments
+
+# Cleanup after merge
+git checkout main && git pull --ff-only origin main
+git branch -d <branch>
+git remote prune origin
+```
+
+## Lint markdown
+
+`.markdownlint.json` configures the linter. Run it before committing
+docs changes:
+
+```sh
+npx markdownlint-cli2 "docs/**/*.md" "*.md" "profile/*.md"
+# or
+npx markdownlint "docs/**/*.md" "*.md" "profile/*.md"
+```
+
+(There is no committed `package.json` - markdownlint runs ad-hoc via
+`npx` or whatever the team has installed.)
+
+## Validate workflow YAML
+
+```sh
+# Syntax check via actionlint (CodeRabbit also runs this on PR)
+actionlint .github/workflows/*.yml workflow-templates/*.yml
+```
+
+## Tag management for reusable workflows
+
+```sh
+# Move v1 to current main
+git tag -f v1
+git push -f origin v1
+
+# Inspect existing tags
+git tag --list
+gh api repos/geolonia/.github/git/refs/tags --jq '.[].ref'
+
+# Cut a new major after a breaking change
+git tag v2
+git push origin v2
+```
+
+## TechDocs preview locally
+
+```sh
+pip install mkdocs-techdocs-core
+mkdocs serve   # local preview at http://127.0.0.1:8000
+```
+
+## Inspect CodeRabbit central config rollout
+
+```sh
+# Confirm the canonical file is reachable
+curl -fsSL https://raw.githubusercontent.com/geolonia/.github/main/.coderabbit.yaml | head
+
+# List which org repos still have a local .coderabbit.yaml
+gh search code 'org:geolonia path:.coderabbit.yaml -filename:.coderabbit.yaml'  # rough audit
+```
+
+## GitHub utilities
+
+```sh
+gh issue create --title "..." --body "..."
+gh issue list --state open
+gh issue close <num> --reason completed --comment "..."
+gh pr list --label dependencies         # find Dependabot PRs
+gh release list --limit 10
+```
+
+## macOS (Darwin) shell utilities
+
+System is Darwin - BSD versions of common tools. Notable differences:
+
+- `sed -i` requires an empty backup arg: `sed -i '' 's/a/b/' file`
+- `find -E` for extended regex (BSD)
+- `date -d` unavailable; use `gdate` (`brew install coreutils`) or `date -j`
+- `pbcopy` / `pbpaste` for clipboard

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,92 @@
+# Task completion checklist
+
+Run before opening a PR. This repo has no automated test pipeline, so
+the checklist relies on a few targeted manual checks.
+
+## 1. Lint markdown (if you touched any .md)
+
+```sh
+npx markdownlint-cli2 "docs/**/*.md" "*.md" "profile/*.md"
+```
+
+Fix anything flagged before committing.
+
+## 2. Validate workflow YAML (if you touched .github/workflows or workflow-templates)
+
+```sh
+actionlint .github/workflows/*.yml workflow-templates/*.yml
+```
+
+CodeRabbit will also run actionlint on the PR; fixing locally first
+saves a review round.
+
+## 3. Em-dash check
+
+This repo's `AGENTS.md` forbids em-dashes (`-`) anywhere - markdown,
+YAML, commit messages, PR text. Verify:
+
+```sh
+git diff --cached | grep -E '\xe2\x80\x94' && echo "FAIL: em-dash present" || echo "OK"
+```
+
+If you composed the PR body or issue body in a tool that auto-substitutes
+hyphens to em-dashes (Apple Notes, Microsoft Word, etc.), check those
+texts manually too.
+
+## 4. Public-only content sweep
+
+This repo is public. Scan the diff for anything that should not be:
+
+```sh
+git diff --cached | grep -iE 'secret|password|token|api[-_]?key|@<your-org-domain>'
+```
+
+Hits don't always indicate a leak (the word "secret" appears in
+documentation), but every match deserves a deliberate look.
+
+## 5. Tag-pinning sanity (if you touched workflow-templates)
+
+If you changed a template that references a reusable workflow, confirm
+the tag it points at exists:
+
+```sh
+gh api repos/geolonia/.github/git/refs/tags --jq '.[].ref'
+```
+
+## 6. CodeRabbit central-config sanity (if you touched .coderabbit.yaml)
+
+This file is fetched by every other Geolonia repo. After merging, the
+next PR opened in any repo will see the new settings. Before merging,
+double-check:
+
+- YAML parses (CodeRabbit will tell you on the PR; verify locally with
+  `yamllint .coderabbit.yaml` if installed).
+- No setting is too repo-specific - central config should apply org-wide.
+- Plan a rollback: a quick revert PR is the right response if the new
+  config produces noisy or wrong reviews.
+
+## 7. Cross-impact of community-health edits
+
+If you touched a community-health file (`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`,
+`SUPPORT.md`, `SECURITY.md`, `.github/ISSUE_TEMPLATE/*`, or
+`.github/pull_request_template.md`), remember the change cascades to
+every Geolonia repo that doesn't override locally. Higher-stakes than
+a typical doc edit.
+
+## 8. Open the PR
+
+- Title under 70 chars, conventional-commit prefix.
+- Body follows the org PR template - Summary, link to issue
+  (`Fixes #N` / `Refs #N`), test plan.
+- Wait for CodeRabbit review.
+- Resolve every CodeRabbit thread after fixing (per global memory
+  `global/issue-first-pr-workflow`).
+- One human approval before merge.
+
+## Red flags
+
+- Any sensitive-looking string in the diff - abort and clean up first.
+- Em-dashes anywhere in your changes.
+- Bumping a tag (`v1`, `v2`) on a reusable workflow without a release
+  note explaining what changed.
+- Editing `.coderabbit.yaml` without a clear rollback plan.

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -26,7 +26,7 @@ This repo's `AGENTS.md` forbids em-dashes (`-`) anywhere - markdown,
 YAML, commit messages, PR text. Verify:
 
 ```sh
-git diff --cached | grep -E '\xe2\x80\x94' && echo "FAIL: em-dash present" || echo "OK"
+git diff --cached | grep $'\xe2\x80\x94' && echo "FAIL: U+2014 present" || echo "OK"
 ```
 
 If you composed the PR body or issue body in a tool that auto-substitutes

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -22,8 +22,9 @@ saves a review round.
 
 ## 3. Em-dash check
 
-This repo's `AGENTS.md` forbids em-dashes (`-`) anywhere - markdown,
-YAML, commit messages, PR text. Verify:
+This repo's `AGENTS.md` forbids the em-dash character (Unicode
+codepoint U+2014) anywhere - markdown, YAML, commit messages, PR
+text. See `code_style` for the longer rationale. Verify:
 
 ```sh
 git diff --cached | grep $'\xe2\x80\x94' && echo "FAIL: U+2014 present" || echo "OK"

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "_github"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- markdown
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary
Drop the blanket `.serena/` exclusion from `.gitignore` and start tracking Serena's project config and onboarding memories - mirroring the pattern already landed in `geolonia/geolonia-datastore#38` and `geolonia/geolonia-sitestore#35`. Because **this repo is public**, the memories were scrubbed first.

## Sensitive-content scrub (before publishing)

- **`project_overview.md`** - dropped the parenthetical naming the `geolonia-operations` parent workspace. The repo's identity does not depend on that internal-checkout detail.
- **`shared_coderabbit_config.md`** - dropped the "Repo rollout history" section that referenced `geolonia/geolonia-operations#54` and `#55` (those issues live in a private repo; the integer references would have confirmed its existence and mild activity-level metadata).

No other memory mentioned anything internal.

## New memory: `public_repo_hygiene.md`

So future agents (Serena, Claude, others) check before adding new content to this repo. Covers:

- **Forbidden categories**: secrets, AWS account IDs / ARNs, internal hostnames, references to private repos, customer data, staff personal data, internal-only opinions.
- **Allowed and useful content**: public URLs, generic patterns, names (not values) of org secrets, "how this org works" documentation.
- **"When in doubt" guidance**: describe the pattern, not the specific internal artifact.
- **Pre-PR verification greps** for private-repo refs, likely secrets, AWS account IDs.
- **Steps if a leak has already shipped**.

`project_overview.md`'s Critical Constraints section now points at this new memory.

## What gets tracked
```
.serena/.gitignore                                  # excludes cache/ + project.local.yml
.serena/project.yml                                 # project metadata
.serena/memories/
├── agent_policy_summary.md
├── code_style.md
├── community_health_and_templates.md
├── project_overview.md          (scrubbed)
├── project_structure.md
├── public_repo_hygiene.md       (new)
├── reusable_workflows.md
├── shared_coderabbit_config.md  (scrubbed)
├── suggested_commands.md
└── task_completion_checklist.md
```

## Test plan
- [x] Em-dash sweep on the diff: clean (the few matches are inside `public_repo_hygiene.md` defining its own ban, same pattern as `code_style.md`'s em-dash rule).
- [x] `git diff --cached | grep -E 'geolonia-operations|repos/_'` hits only the new hygiene memory's example text (the rule naming what it bans), nowhere else.
- [x] Each remaining memory eyeballed for public-safety: no secrets, no internal hostnames, no customer data, no staff personal data.
- [ ] CodeRabbit review addressed.

## Notes
No code or workflow change. Pure repo hygiene + agent onboarding context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Clarified repository ignore rules (track project metadata, ignore local caches) and added a project configuration file.

* **Documentation**
  * Added comprehensive org-level guidance: agent policy, code/style conventions, community health and templates, project overview and structure, public-repo hygiene, reusable workflow conventions, shared tool configuration, suggested commands, and a task-completion checklist.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/23)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->