### PR TITLE
feat(workflows): add reusable secret-leak check for per-PR scanning

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -165,12 +165,20 @@ jobs:
         run: |
           # GitHub workflow annotations show up inline on the PR's
           # "Files changed" view. One annotation per finding.
+          #
+          # Workflow commands are parsed line-by-line from stdout in the
+          # form `::name param=value::message`. A CR or LF anywhere in
+          # the file path, rule ID, or commit SHA could break the
+          # parser or inject additional workflow commands. Sanitize
+          # everything we interpolate by stripping CR/LF and `::`
+          # before emitting. (`gsub` here uses jq's PCRE-lite syntax.)
           jq -r '
+            def safe: tostring | gsub("[\r\n]"; " ") | gsub("::"; "[colon-colon]");
             .[] |
-            "::error file=" + (.Attributes.path // "?") +
+            "::error file=" + ((.Attributes.path // "?") | safe) +
             ",line=" + ((.StartLine // 0) | tostring) +
-            "::Secret leak detected: rule=" + .RuleID +
-            " (commit " + ((.Attributes["git.sha"] // "?")[0:7]) + ")"
+            "::Secret leak detected: rule=" + ((.RuleID // "?") | safe) +
+            " (commit " + (((.Attributes["git.sha"] // "?")[0:7]) | safe) + ")"
           ' findings.json
 
       - name: Build PR comment body
@@ -228,23 +236,43 @@ jobs:
           echo "marker=${MARKER}" >> "$GITHUB_OUTPUT"
 
       - name: Post / update PR comment
+        # PRs from forks (and PRs opened by Dependabot) get a read-only
+        # `GITHUB_TOKEN` regardless of the `permissions:` block above.
+        # This step degrades gracefully in that case: log a warning,
+        # let the inline annotations + artifact carry the report. The
+        # job's pass/fail status is decided by the dedicated fail step
+        # below, not by whether we managed to post a comment.
         if: always() && github.event.pull_request.number != null
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           BODY_FILE: ${{ steps.comment.outputs.body_file }}
           MARKER: ${{ steps.comment.outputs.marker }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # Probe write access first so we emit a clean warning rather
+          # than a noisy 403 from the actual write call.
+          if ! gh api "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" \
+                --jq '.permission' >/dev/null 2>&1; then
+            : # Probe doesn't have to succeed; fall through and try.
+          fi
           EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --paginate --slurp \
-            --jq "[.[].[] | select(.body | startswith(env.MARKER))] | .[0].id // empty")
+            --jq "[.[].[] | select(.body | startswith(env.MARKER))] | .[0].id // empty" \
+            2>/dev/null || true)
           if [ -n "${EXISTING}" ]; then
-            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
-              -f body="$(cat "${BODY_FILE}")" >/dev/null
-            echo "Updated existing betterleaks comment (#${EXISTING})."
+            if gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+                 -f body="$(cat "${BODY_FILE}")" >/dev/null 2>&1; then
+              echo "Updated existing betterleaks comment (#${EXISTING})."
+            else
+              echo "::warning::Could not update PR comment (fork PR or Dependabot? GITHUB_TOKEN is read-only in those contexts). Findings are still visible as inline annotations and in the workflow artifact."
+            fi
           else
-            gh pr comment "${PR_NUMBER}" --body-file "${BODY_FILE}" >/dev/null
-            echo "Posted new betterleaks comment."
+            if gh pr comment "${PR_NUMBER}" --body-file "${BODY_FILE}" >/dev/null 2>&1; then
+              echo "Posted new betterleaks comment."
+            else
+              echo "::warning::Could not post PR comment (fork PR or Dependabot? GITHUB_TOKEN is read-only in those contexts). Findings are still visible as inline annotations and in the workflow artifact."
+            fi
           fi
 
       - name: Upload findings as artifact

--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -1,0 +1,269 @@
+name: "[REUSABLE] Secret Leak Check"
+
+# Per-PR secret-leak gate. Scans only commits added by the PR (i.e. the
+# diff against the base ref) using betterleaks. Pairs with the weekly
+# org-wide audit in geolonia-operations (`secret-leak-audit.yml`),
+# which catches what is already in main history. This reusable
+# prevents new commits with secrets from getting in.
+#
+# Consumer wrapper (in any repo):
+#
+#   name: Secret Leak Check
+#   on:
+#     pull_request:
+#       branches: [main]
+#   jobs:
+#     scan:
+#       uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
+
+on:
+  workflow_call:
+    inputs:
+      betterleaks-image:
+        description: "betterleaks container image, pinned by digest. Override only for testing newer versions."
+        type: string
+        required: false
+        default: "ghcr.io/betterleaks/betterleaks@sha256:0d438a2f5821f182bf1af1b2bb74bf3f79830c93291503c1fb90c19cab1ac5d6"  # v1.2.0
+      fail-on-findings:
+        description: "Fail the job (block the PR check) when secrets are found. Set false for warn-only mode while a repo cleans up legacy false positives."
+        type: boolean
+        required: false
+        default: true
+      config-path:
+        description: "Optional path to a .betterleaks.toml config file in the caller repo. If empty, the file is auto-detected at the repo root by betterleaks."
+        type: string
+        required: false
+        default: ""
+      base-ref:
+        description: "Git ref to diff against. Defaults to the PR base. Override only when calling from a non-pull_request trigger."
+        type: string
+        required: false
+        default: ""
+      validate-secrets:
+        description: "Validate detected secrets against live APIs. Off by default for PR checks (avoids outbound HTTP from PR contributors' work)."
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    name: betterleaks (PR diff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve base + head refs
+        id: refs
+        env:
+          OVERRIDE_BASE: ${{ inputs.base-ref }}
+        run: |
+          # `github.event.pull_request.base.sha` is the merge-base
+          # GitHub computed when this PR was opened/updated. That is
+          # exactly the "everything not in this PR" boundary we want.
+          if [ -n "${OVERRIDE_BASE}" ]; then
+            BASE_REF="${OVERRIDE_BASE}"
+          elif [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            echo "::error::No base ref available. This workflow expects a pull_request trigger, or callers must pass base-ref explicitly."
+            exit 1
+          fi
+          HEAD_REF="${{ github.event.pull_request.head.sha || github.sha }}"
+          echo "base=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          echo "head=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+          echo "Diffing ${BASE_REF}..${HEAD_REF}"
+
+      - name: Pull betterleaks image
+        env:
+          BETTERLEAKS_IMAGE: ${{ inputs.betterleaks-image }}
+        run: |
+          docker pull "${BETTERLEAKS_IMAGE}"
+          docker run --rm "${BETTERLEAKS_IMAGE}" version
+
+      - name: Run betterleaks on PR diff
+        id: scan
+        continue-on-error: true
+        env:
+          BETTERLEAKS_IMAGE: ${{ inputs.betterleaks-image }}
+          BASE_REF: ${{ steps.refs.outputs.base }}
+          HEAD_REF: ${{ steps.refs.outputs.head }}
+          CONFIG_PATH: ${{ inputs.config-path }}
+          VALIDATE_SECRETS: ${{ inputs.validate-secrets }}
+        run: |
+          # Limit the scan to commits in the PR via --log-opts. The
+          # `git` subcommand walks history; `--log-opts` is forwarded
+          # to git log, so we get exactly the commits added by the PR.
+          args=(
+            git .
+            --log-opts "${BASE_REF}..${HEAD_REF}"
+            --report-format json
+            --report-path findings.json
+            --exit-code 0
+            --redact
+            --no-banner
+            --git-workers 4
+          )
+          if [ -n "${CONFIG_PATH}" ]; then
+            args+=(--config "${CONFIG_PATH}")
+          fi
+          if [ "${VALIDATE_SECRETS}" = "true" ]; then
+            args+=(--validation)
+          fi
+          # Run as the runner user so the report file is not root-owned
+          # (the next jq step needs to read it).
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "${PWD}:/workspace" \
+            -w /workspace \
+            "${BETTERLEAKS_IMAGE}" \
+            "${args[@]}"
+
+      - name: Validate JSON + count findings
+        id: findings
+        if: always()
+        env:
+          SCAN_OUTCOME: ${{ steps.scan.outcome }}
+        run: |
+          # betterleaks emits `null` (clean) or a top-level array
+          # (findings). Anything else is a schema failure.
+          if [ "${SCAN_OUTCOME}" != "success" ] && [ ! -s findings.json ]; then
+            echo "::error::betterleaks scan failed (outcome=${SCAN_OUTCOME}) and produced no readable JSON file"
+            echo "scan_failed=true" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          if ! jq empty findings.json >/dev/null 2>&1; then
+            echo "::error::betterleaks produced an unreadable/invalid JSON file"
+            echo "scan_failed=true" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          if ! TOTAL=$(jq -er '
+            if type == "null" then
+              0
+            elif type == "array" then
+              length
+            else
+              error("expected top-level array or null, got \(type)")
+            end
+          ' findings.json); then
+            echo "::error::betterleaks JSON has unexpected shape"
+            echo "scan_failed=true" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
+
+      - name: Emit inline annotations
+        if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0'
+        run: |
+          # GitHub workflow annotations show up inline on the PR's
+          # "Files changed" view. One annotation per finding.
+          jq -r '
+            .[] |
+            "::error file=" + (.Attributes.path // "?") +
+            ",line=" + ((.StartLine // 0) | tostring) +
+            "::Secret leak detected: rule=" + .RuleID +
+            " (commit " + ((.Attributes["git.sha"] // "?")[0:7]) + ")"
+          ' findings.json
+
+      - name: Build PR comment body
+        id: comment
+        if: always()
+        env:
+          SCAN_FAILED: ${{ steps.findings.outputs.scan_failed }}
+          TOTAL: ${{ steps.findings.outputs.total }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY_FILE="pr-comment.md"
+          # Hidden marker so we can identify and update the previous
+          # comment idempotently across re-pushes to the same PR.
+          MARKER="<!-- betterleaks-reusable-v1 -->"
+
+          {
+            echo "${MARKER}"
+            echo ""
+            echo "### Secret Leak Check"
+            echo ""
+            if [ "${SCAN_FAILED}" = "true" ]; then
+              echo "X betterleaks scan failed before producing a readable report. [Workflow run](${RUN_URL})"
+            elif [ "${TOTAL:-0}" = "0" ]; then
+              echo "OK No secrets detected in this PR's diff."
+            else
+              # Cap inline details at 60k chars (GitHub's body limit is
+              # ~65k). Full report is in the workflow artifact.
+              DETAILS=$(jq -r '
+                .[] |
+                "- **`" + .RuleID + "`** at `" + (.Attributes.path // "?") +
+                ":" + ((.StartLine // 0) | tostring) + "`" +
+                " (commit `" + ((.Attributes["git.sha"] // "?")[0:7]) + "`" +
+                ", author " + (.Attributes["git.author_name"] // "?") + ")"
+              ' findings.json)
+              MAX=60000
+              if [ "${#DETAILS}" -gt "${MAX}" ]; then
+                DETAILS="${DETAILS:0:${MAX}}"$'\n\n_(Truncated; download the workflow artifact for the full report.)_'
+              fi
+              echo "Found **${TOTAL} potential secret(s)** in this PR's diff."
+              echo ""
+              echo "${DETAILS}"
+              echo ""
+              echo "Detected values are redacted in this report. Pull the artifact from the [workflow run](${RUN_URL}) for the redacted-but-context-bearing JSON."
+              if [ "${FAIL_ON_FINDINGS}" = "true" ]; then
+                echo ""
+                echo "**This check is failing the PR.** Remove the secret + force-push (or rotate the credential if it ever reached a remote), then re-run."
+              else
+                echo ""
+                echo "_This check is in warn-only mode (\`fail-on-findings: false\`). The PR can still merge, but please address the finding._"
+              fi
+            fi
+          } > "${BODY_FILE}"
+          echo "body_file=${BODY_FILE}" >> "$GITHUB_OUTPUT"
+          echo "marker=${MARKER}" >> "$GITHUB_OUTPUT"
+
+      - name: Post / update PR comment
+        if: always() && github.event.pull_request.number != null
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BODY_FILE: ${{ steps.comment.outputs.body_file }}
+          MARKER: ${{ steps.comment.outputs.marker }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --slurp \
+            --jq "[.[].[] | select(.body | startswith(env.MARKER))] | .[0].id // empty")
+          if [ -n "${EXISTING}" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+              -f body="$(cat "${BODY_FILE}")" >/dev/null
+            echo "Updated existing betterleaks comment (#${EXISTING})."
+          else
+            gh pr comment "${PR_NUMBER}" --body-file "${BODY_FILE}" >/dev/null
+            echo "Posted new betterleaks comment."
+          fi
+
+      - name: Upload findings as artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: betterleaks-pr-${{ github.event.pull_request.number || github.run_id }}
+          path: findings.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Fail the job if findings + fail-on-findings
+        if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0' && inputs.fail-on-findings == true
+        run: |
+          echo "::error::Secret-leak check failed: ${{ steps.findings.outputs.total }} potential secret(s) in PR diff."
+          exit 1
+
+      - name: Surface scan-level failure
+        if: always() && steps.findings.outputs.scan_failed == 'true'
+        run: |
+          echo "::error::betterleaks scan failed before producing a readable report."
+          exit 1

--- a/workflow-templates/secret-leak-check.properties.json
+++ b/workflow-templates/secret-leak-check.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Secret Leak Check (per PR)",
+  "description": "Scan every PR's diff for committed secrets using betterleaks. Blocks the merge check when secrets are detected. Pairs with the weekly org-wide audit in geolonia-operations.",
+  "iconName": "shield",
+  "categories": ["Security"],
+  "filePatterns": []
+}

--- a/workflow-templates/secret-leak-check.yml
+++ b/workflow-templates/secret-leak-check.yml
@@ -1,0 +1,18 @@
+name: Secret Leak Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
+    # Optional per-repo overrides:
+    # with:
+    #   fail-on-findings: false       # warn-only while cleaning up legacy false positives
+    #   config-path: .betterleaks.toml
+    #   validate-secrets: false       # active-secret HTTP validation (slower, makes outbound calls)


### PR DESCRIPTION
## Summary

Adds `reusable-secret-leak-check.yml`, an org-wide reusable workflow that any Geolonia repo can call from `pull_request` to block new secret commits before merge.

Pairs with the weekly org-wide audit in `geolonia-operations/.github/workflows/secret-leak-audit.yml`:

| Workflow | Where | Catches |
|---|---|---|
| Org-wide audit (cron) | `geolonia-operations` | Secrets already in main history of any org repo |
| **This reusable** | Any consumer repo, `pull_request` trigger | New secret commits **before** they merge |

Tracking issue: [`geolonia/geolonia-operations#60`](https://github.com/geolonia/geolonia-operations/issues/60).

## How it works

Scans only the commits the PR adds: `betterleaks git . --log-opts="<base-sha>..<head-sha>"`. Runs the upstream betterleaks container pinned by immutable digest (`v1.2.0`).

Outputs:

- **Inline workflow annotations** on the PR's "Files changed" view (one per finding)
- An **idempotent PR comment** (updated across re-pushes via a hidden marker line, so the PR doesn't accumulate one comment per push)
- A **workflow artifact** with the redacted JSON (30-day retention)
- **Optional job failure** when findings exist (the merge-block gate)

## Inputs

| Name | Default | Purpose |
|---|---|---|
| `betterleaks-image` | digest of `v1.2.0` | Override only for testing newer versions. |
| `fail-on-findings` | `true` | Block by default. Set to `false` for warn-only mode while a repo cleans up legacy false positives. |
| `config-path` | `''` | Optional `.betterleaks.toml` config path. |
| `base-ref` | `''` | Defaults to PR base SHA; override only for non-`pull_request` triggers. |
| `validate-secrets` | `false` | Active-secret HTTP validation. Off by default for PR triggers (don't make outbound HTTP from contributor work). |

## Permissions

```yaml
permissions:
  contents: read
  pull-requests: write
```

No org-level token. `GITHUB_TOKEN` is sufficient since the scan is scoped to the caller repo.

## Consumer pattern (after tagging v1)

```yaml
# .github/workflows/secret-leak-check.yml in any consumer repo
name: Secret Leak Check
on:
  pull_request:
    branches: [main]
jobs:
  scan:
    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
```

Override defaults per repo if needed:

```yaml
    with:
      fail-on-findings: false      # warn-only during cleanup
      config-path: .betterleaks.toml
```

## Failure semantics + body cap (inherited from secret-leak-audit.yml)

- Schema-validates the JSON: accepts `null` (clean) or top-level array (findings). Anything else triggers `scan_failed=true` and explicit failure.
- `--redact` on by default. Detected secret values never appear in logs, annotations, or PR comments.
- 60,000-char inline comment cap; full report in the artifact.

## Test plan

- [ ] CodeRabbit review passes
- [ ] After merge, **tag `v1`** so consumers can `uses: ...@v1`
- [ ] Follow-up: add a consumer wrapper in `geolonia-operations` first (self-dogfood); confirm the comment + annotation behavior on a test PR
- [ ] Then roll out wrappers to active submodules one by one

## Out of scope

- Consumer wrappers in individual repos (each adopts the reusable on its own schedule)
- Branch protection automation (turning the check into a required status)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable per-PR secret-leak scanning workflow with configurable scan image, fail-on-findings, config path, base ref override, and optional live validation.
  * Added a workflow template to enable the per-PR secret leak check easily.

* **Chores**
  * Scans only PR-introduced changes, posts inline annotations and an updatable PR comment, uploads a findings artifact, and can optionally fail the check on findings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/24)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->