### PR TITLE
feat(secret-leak-check): org-wide betterleaks default config

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -30,10 +30,15 @@ on:
         required: false
         default: true
       config-path:
-        description: "Optional path to a .betterleaks.toml config file in the caller repo. If empty, the file is auto-detected at the repo root by betterleaks."
+        description: "Path to a .betterleaks.toml config file in the caller repo. If empty, the workflow falls back to the org-wide default fetched from geolonia/.github (betterleaks/default.toml). To skip the org default and let betterleaks auto-detect a repo-root .betterleaks.toml only, set this to '.betterleaks.toml'."
         type: string
         required: false
         default: ""
+      org-config-ref:
+        description: "Git ref of geolonia/.github to fetch the org-wide betterleaks/default.toml from. Defaults to main; pin to a tag if you want a frozen baseline."
+        type: string
+        required: false
+        default: "main"
       base-ref:
         description: "Git ref to diff against. Defaults to the PR base. Override only when calling from a non-pull_request trigger."
         type: string
@@ -89,6 +94,23 @@ jobs:
           docker pull "${BETTERLEAKS_IMAGE}"
           docker run --rm "${BETTERLEAKS_IMAGE}" version
 
+      - name: Fetch org-wide betterleaks config (fallback when caller did not provide one)
+        if: inputs.config-path == ''
+        env:
+          ORG_CONFIG_REF: ${{ inputs.org-config-ref }}
+        run: |
+          # Pulled from geolonia/.github at the ref the caller specified
+          # (default: main). Rationale and edit policy live in the toml
+          # itself. We pin via SHA-of-fetched-file in the workflow log so
+          # an unexpected change is at least visible in run output.
+          set -euo pipefail
+          curl -fsSL \
+            "https://raw.githubusercontent.com/geolonia/.github/${ORG_CONFIG_REF}/betterleaks/default.toml" \
+            -o .betterleaks-org-default.toml
+          echo "Fetched org-wide config from geolonia/.github@${ORG_CONFIG_REF}:"
+          sha256sum .betterleaks-org-default.toml
+          cat .betterleaks-org-default.toml
+
       - name: Run betterleaks on PR diff
         id: scan
         continue-on-error: true
@@ -114,6 +136,8 @@ jobs:
           )
           if [ -n "${CONFIG_PATH}" ]; then
             args+=(--config "${CONFIG_PATH}")
+          elif [ -f .betterleaks-org-default.toml ]; then
+            args+=(--config .betterleaks-org-default.toml)
           fi
           if [ "${VALIDATE_SECRETS}" = "true" ]; then
             args+=(--validation)

--- a/betterleaks/default.toml
+++ b/betterleaks/default.toml
@@ -1,0 +1,36 @@
+# Org-wide betterleaks config for Geolonia repositories.
+#
+# This file is consumed automatically by:
+#
+#   1. The reusable per-PR scan workflow
+#      (.github/workflows/reusable-secret-leak-check.yml) when the
+#      caller did not pass a `config-path` input.
+#
+#   2. The weekly org-wide audit workflow
+#      (geolonia/geolonia-operations/.github/workflows/secret-leak-audit.yml)
+#      via the same fetch-and-fallback pattern.
+#
+# Per-repo overrides:
+#
+#   - Commit a `.betterleaks.toml` at the root of your repository to
+#     extend or replace this config. The reusable workflow auto-detects
+#     it (or you can pass an explicit `config-path` input).
+#
+# Why `generic-api-key` is disabled:
+#
+#   In our org baseline (May 2026, 708 repos), `generic-api-key`
+#   produced 1,838 of 2,381 findings, with a sample noise rate of
+#   ~95%. Most hits are public-by-design values: Geolonia map tile
+#   API keys embedded in HTML widgets, Stripe publishable keys
+#   (`pk_test_`, `pk_live_`), Amplify GraphQL keys (`da2-`), JWT
+#   examples in docs, content hashes, build artifacts. Targeted rules
+#   (`stripe-access-token`, `aws-access-token`, `anthropic-api-key`,
+#   `slack-bot-token`, `jwt`, `private-key`, etc.) catch the same
+#   threat class via specific token shapes and stay enabled. Disabling
+#   `generic-api-key` org-wide cuts the noise without losing real
+#   coverage. A repo that wants the rule on can re-enable it in its
+#   own `.betterleaks.toml`.
+
+[extend]
+useDefault = true
+disabledRules = ["generic-api-key"]


### PR DESCRIPTION
## Summary

Adds \`betterleaks/default.toml\` to disable the noisy \`generic-api-key\` rule org-wide. The reusable per-PR scan workflow auto-fetches this config when the caller did not pass a \`config-path\` input.

## Why

Org-wide baseline scan (May 2026, 708 repos): 2381 findings.

- \`generic-api-key\`: **1838 hits** with sampled noise rate ~95% (Geolonia map tile API keys in HTML widgets, Stripe \`pk_\` keys, Amplify \`da2-\` keys, JWT examples in docs, content hashes, build artifacts)
- All other rules combined: 543 hits, most signal-heavy

Disabling \`generic-api-key\` drops findings to ~543 across ~50 repos — small enough for owners to actually triage.

## Mechanism

1. Caller supplies \`config-path\`? Use it (per-repo override path).
2. Empty? Workflow curls \`betterleaks/default.toml\` from \`geolonia/.github@<org-config-ref>\` (defaults to \`main\`) and passes it as \`--config\`. SHA logged in run output for traceability.

The new \`org-config-ref\` input lets a caller pin to a tag if they want a frozen baseline.

## Test plan

- [ ] CodeRabbit clean
- [ ] CI: tag-on-release workflow promotes to v1.x after merge
- [ ] Next time a PR runs against this reusable, the workflow log shows the fetched config + SHA
- [ ] Org weekly cron in geolonia-operations to be updated separately to use the same default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-wide secret detection configuration that automatically applies to repositories lacking local configurations
  * Introduced new input parameter for specifying organization configuration reference

* **Documentation**
  * Updated input descriptions to document fallback behavior, configuration precedence, and per-repository override options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->