### PR TITLE
fix(release-auto-on-tag): align input declaration with secret name

### DIFF
--- a/.github/workflows/reusable-release-auto-on-tag.yml
+++ b/.github/workflows/reusable-release-auto-on-tag.yml
@@ -45,8 +45,8 @@ on:
         description: "Minor tag (e.g. v1.2)"
         value: ${{ jobs.release.outputs.minor }}
     secrets:
-      WORKFLOWS_APP_ID:
-        description: "GitHub App ID for pushing tags"
+      WORKFLOWS_CLIENT_ID:
+        description: "GitHub App client ID for pushing tags (consumed by actions/create-github-app-token@v3 as `client-id`)."
         required: true
       WORKFLOWS_APP_PRIVATE_KEY:
         description: "GitHub App private key for pushing tags"


### PR DESCRIPTION
## Summary

The reusable release workflow declared its secret as \`WORKFLOWS_APP_ID\` but used \`secrets.WORKFLOWS_CLIENT_ID\` at the call site. Renames the declaration to match the lookup so the workflow is self-documenting.

## Why the failing run failed

[runs/25849532494](https://github.com/geolonia/.github/actions/runs/25849532494) errored with \`The 'client-id' input must be set to a non-empty string\`. Root cause: \`WORKFLOWS_CLIENT_ID\` org secret was \`PRIVATE\` visibility, but \`geolonia/.github\` is a public repo, so the value resolved to empty. Visibility has been widened separately. This PR fixes the documentation gap that would have made the next reader equally confused.

## Fixes

geolonia/.github#25

## Test plan

- [ ] CodeRabbit clean
- [ ] After merge, tag \`v1.x\` on this repo and verify the publish workflow runs green
- [ ] Close Issue #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release automation workflow to enhance security for automated tag creation processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->