### PR TITLE
fix(workflow-templates): use GitHub-recognized categories

### DIFF
--- a/workflow-templates/publish-techdocs.properties.json
+++ b/workflow-templates/publish-techdocs.properties.json
@@ -2,6 +2,6 @@
   "name": "Publish Backstage TechDocs",
   "description": "Generate and publish Backstage TechDocs to S3 using Geolonia's standard settings (OIDC). Optional per-repo overrides supported.",
   "iconName": "book",
-  "categories": ["Documentation"],
+  "categories": ["Deployment"],
   "filePatterns": ["docs/**", "mkdocs.yml"]
 }

--- a/workflow-templates/secret-leak-check.properties.json
+++ b/workflow-templates/secret-leak-check.properties.json
@@ -2,6 +2,6 @@
   "name": "Secret Leak Check (per PR)",
   "description": "Scan every PR's diff for committed secrets using betterleaks. Blocks the merge check when secrets are detected. Pairs with the weekly org-wide audit in geolonia-operations.",
   "iconName": "shield",
-  "categories": ["Security"],
+  "categories": ["Code scanning"],
   "filePatterns": []
 }


### PR DESCRIPTION
## Summary

Both Publish Backstage TechDocs and Secret Leak Check (per PR) had \`categories\` defined, but GitHub's workflow-template UI silently dropped the badge because the values were not in the recognized set.

| Template | Was | Now |
|---|---|---|
| secret-leak-check | \`["Security"]\` | \`["Code scanning"]\` |
| publish-techdocs | \`["Documentation"]\` | \`["Deployment"]\` |

The recognized set per [actions/starter-workflows](https://github.com/actions/starter-workflows) is: Automation, Code scanning, Continuous integration, Deployment, Pages.

## Test plan

- [ ] After merge, refresh https://github.com/<repo>/actions/new — both templates should now show their category badge alongside the other three.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated categorization for workflow templates. The "Publish TechDocs" workflow is now categorized as Deployment, and the secret-leak-check workflow is now categorized as Code scanning for improved organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->