### PR TITLE
feat(betterleaks): add placeholder allowlists to org config

### DIFF
--- a/betterleaks/default.toml
+++ b/betterleaks/default.toml
@@ -51,9 +51,10 @@ regexes = [
 ]
 
 [[allowlists]]
-description = "Angle-bracket placeholders: <your-token>, <api-key>, <endpoint-url>"
+description = "Angle-bracket placeholders: <your-token>, <api-key>, <endpoint-url> (incl. Japanese)"
 regexes = [
-  '''<[A-Za-z\p{Han}\p{Hiragana}\p{Katakana}][^>]{1,60}>''',
+  # Inner-char ranges: ASCII letter | Hiragana | Katakana | CJK Unified Ideographs
+  '''<[A-Za-z\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}][^>]{1,60}>''',
 ]
 
 [[allowlists]]
@@ -67,13 +68,12 @@ regexes = [
 [[allowlists]]
 description = "Standard placeholder words: REPLACE_ME / EXAMPLE / PLACEHOLDER / CHANGEME"
 regexes = [
-  '''(?i)\b(REPLACE[-_]?ME|CHANGE[-_]?ME|PLACEHOLDER|EXAMPLE[-_]?(KEY|TOKEN|SECRET)?|FAKE[-_]?(KEY|TOKEN|SECRET)?|SAMPLE[-_]?(KEY|TOKEN|SECRET))\b''',
+  '''(?i)\b(REPLACE[-_]?ME|CHANGE[-_]?ME|PLACEHOLDER|EXAMPLE[-_]?(KEY|TOKEN|SECRET)?|FAKE[-_]?(KEY|TOKEN|SECRET)?|SAMPLE[-_]?(KEY|TOKEN|SECRET)?)\b''',
 ]
 
 [[allowlists]]
-description = "Obvious dev / test scaffold tokens"
+description = "Obvious dev / test scaffold tokens (must include credential context)"
 regexes = [
   '''(?i)\bdev[-_]?local[-_]?token[-_]?please[-_]?change\b''',
-  '''(?i)\bplease[-_]?(change|update|replace|rotate)\b''',
   '''(?i)\b(test|sample|dummy|dev|stub)[-_]?(token|key|secret|password)[-_]?(here|value)?\b''',
 ]

--- a/betterleaks/default.toml
+++ b/betterleaks/default.toml
@@ -34,3 +34,46 @@
 [extend]
 useDefault = true
 disabledRules = ["generic-api-key"]
+
+# Org-wide allowlist: patterns that are unmistakably documentation
+# placeholders, never accidentally matching a real secret. Add new
+# entries here only if they survive a sanity check ("could this regex
+# match a real credential?"). Each entry includes a short rationale.
+#
+# Allowlists match against the captured Secret value (not the
+# surrounding Match), so the regex should describe just the literal
+# placeholder string.
+
+[[allowlists]]
+description = "YOUR_API_KEY / YOUR-API-KEY / YOUR_TOKEN family (API docs templates)"
+regexes = [
+  '''(?i)\bYOUR[-_](API[-_]?KEY|TOKEN|SECRET|CLIENT[-_]?(ID|SECRET))\b''',
+]
+
+[[allowlists]]
+description = "Angle-bracket placeholders: <your-token>, <api-key>, <endpoint-url>"
+regexes = [
+  '''<[A-Za-z\p{Han}\p{Hiragana}\p{Katakana}][^>]{1,60}>''',
+]
+
+[[allowlists]]
+description = "Famous example UUIDs used in API docs"
+regexes = [
+  '''(?i)550e8400-e29b-41d4-a716-446655440000''',
+  '''00000000-0000-0000-0000-000000000000''',
+  '''(?i)deadbeef-dead-beef-dead-beefdeadbeef''',
+]
+
+[[allowlists]]
+description = "Standard placeholder words: REPLACE_ME / EXAMPLE / PLACEHOLDER / CHANGEME"
+regexes = [
+  '''(?i)\b(REPLACE[-_]?ME|CHANGE[-_]?ME|PLACEHOLDER|EXAMPLE[-_]?(KEY|TOKEN|SECRET)?|FAKE[-_]?(KEY|TOKEN|SECRET)?|SAMPLE[-_]?(KEY|TOKEN|SECRET))\b''',
+]
+
+[[allowlists]]
+description = "Obvious dev / test scaffold tokens"
+regexes = [
+  '''(?i)\bdev[-_]?local[-_]?token[-_]?please[-_]?change\b''',
+  '''(?i)\bplease[-_]?(change|update|replace|rotate)\b''',
+  '''(?i)\b(test|sample|dummy|dev|stub)[-_]?(token|key|secret|password)[-_]?(here|value)?\b''',
+]


### PR DESCRIPTION
## Summary

Adds five \`[[allowlists]]\` blocks to \`betterleaks/default.toml\` so common docs-placeholder patterns no longer trip the targeted rules (mainly \`curl-auth-header\` and \`curl-auth-user\`).

## Sample analysis on the May 2026 baseline

Out of 10 \`curl-auth-header\` findings sampled across distinct repos, 8 were unmistakable placeholders:

| Pattern | Count in sample |
|---|---|
| \`YOUR_API_KEY\` / \`YOUR-API-KEY\` | 5 (kagawa-pref, nasushiobara, nobeoka, gsi-3d, smartcity-geospatial-platform-api) |
| \`<エンドポイントURL>\` angle-bracket | (same files as above) |
| Famous example UUID \`550e8400-e29b-41d4-a716-446655440000\` | 1 (geonicdb-docs) |
| Other docs placeholder (\`gdb_a1b2c3...\`) | 1 (geonicdb) |
| Already-scrubbed dev token | 1 (geolonia-backstage) |
| **Possibly real** | 2 (tokyo-road-manager-api Devise token, yoshioka-town-2025 work log) |

The 2 real-looking ones remain detected; they'll be in the per-repo issues we open next.

## Patterns added

Conservative — every regex is constrained so it cannot match a real credential:

- \`YOUR[-_](API[-_]?KEY|TOKEN|SECRET|CLIENT[-_]?(ID|SECRET))\` — only the literal "YOUR_*" placeholder family
- \`<[A-Za-z\p{Han}\p{Hiragana}\p{Katakana}][^>]{1,60}>\` — angle-bracket placeholders incl. Japanese
- Three specific famous example UUIDs
- \`(REPLACE|CHANGE|PLACEHOLDER|EXAMPLE|FAKE|SAMPLE)[_-]?(ME|KEY|TOKEN|SECRET)?\` — standard placeholder words
- Explicit dev-scaffold patterns (\`dev-local-token-please-change\`, \`please-(change|rotate)\`)

## Test plan

- [ ] CodeRabbit clean
- [ ] After merge, re-run local baseline. \`curl-auth-header\` should drop substantially (estimated to ~60-100 from 329); the 2 real-looking findings (tokyo-road-manager-api Devise token + yoshioka-town-2025 work-log key) should still appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an org-wide allowlist for placeholder values so common documentation/test placeholders (API key templates, angle-bracket tokens, example UUIDs, generic keywords like REPLACE_ME/EXAMPLE/PLACEHOLDER, and obvious dev/test scaffold token phrases) are recognized and excluded from alerts or scans.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->