### PR TITLE
feat(secret-leak-check): add "preset" input (default/strict/minimal)

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -35,7 +35,7 @@ on:
         required: false
         default: "default"
       config-path:
-        description: "Path to a .betterleaks.toml in the caller repo for fully custom config. When set, takes precedence over preset. To skip both preset and org fetch (let betterleaks auto-detect a repo-root .betterleaks.toml), set this to '.betterleaks.toml'."
+        description: "Path to a .betterleaks.toml in the caller repo for fully custom config. When set, the workflow passes it directly as --config and skips the org preset fetch. Point it at a repo-root .betterleaks.toml or any other in-repo path."
         type: string
         required: false
         default: ""

--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -29,13 +29,18 @@ on:
         type: boolean
         required: false
         default: true
+      preset:
+        description: "Org-wide preset to use. 'default' (org-wide baseline, generic-api-key disabled + placeholder allowlists), 'strict' (every detector on, for PII / payments / prod-cred repos), or 'minimal' (only highest-signal token-shape detectors). Ignored if config-path is set."
+        type: string
+        required: false
+        default: "default"
       config-path:
-        description: "Path to a .betterleaks.toml config file in the caller repo. If empty, the workflow falls back to the org-wide default fetched from geolonia/.github (betterleaks/default.toml). To skip the org default and let betterleaks auto-detect a repo-root .betterleaks.toml only, set this to '.betterleaks.toml'."
+        description: "Path to a .betterleaks.toml in the caller repo for fully custom config. When set, takes precedence over preset. To skip both preset and org fetch (let betterleaks auto-detect a repo-root .betterleaks.toml), set this to '.betterleaks.toml'."
         type: string
         required: false
         default: ""
       org-config-ref:
-        description: "Git ref of geolonia/.github to fetch the org-wide betterleaks/default.toml from. Defaults to main; pin to a tag if you want a frozen baseline."
+        description: "Git ref of geolonia/.github to fetch the preset toml from. Defaults to main; pin to a tag if you want a frozen baseline."
         type: string
         required: false
         default: "main"
@@ -94,20 +99,28 @@ jobs:
           docker pull "${BETTERLEAKS_IMAGE}"
           docker run --rm "${BETTERLEAKS_IMAGE}" version
 
-      - name: Fetch org-wide betterleaks config (fallback when caller did not provide one)
+      - name: Fetch org-wide betterleaks preset (used when config-path is empty)
         if: inputs.config-path == ''
         env:
           ORG_CONFIG_REF: ${{ inputs.org-config-ref }}
+          PRESET: ${{ inputs.preset }}
         run: |
           # Pulled from geolonia/.github at the ref the caller specified
           # (default: main). Rationale and edit policy live in the toml
-          # itself. We pin via SHA-of-fetched-file in the workflow log so
-          # an unexpected change is at least visible in run output.
+          # itself. We log the SHA so an unexpected change is at least
+          # visible in run output.
           set -euo pipefail
+          case "${PRESET}" in
+            default|strict|minimal) ;;
+            *)
+              echo "::error::Unknown preset '${PRESET}'. Valid: default, strict, minimal."
+              exit 1
+              ;;
+          esac
           curl -fsSL \
-            "https://raw.githubusercontent.com/geolonia/.github/${ORG_CONFIG_REF}/betterleaks/default.toml" \
+            "https://raw.githubusercontent.com/geolonia/.github/${ORG_CONFIG_REF}/betterleaks/${PRESET}.toml" \
             -o .betterleaks-org-default.toml
-          echo "Fetched org-wide config from geolonia/.github@${ORG_CONFIG_REF}:"
+          echo "Fetched org preset '${PRESET}' from geolonia/.github@${ORG_CONFIG_REF}:"
           sha256sum .betterleaks-org-default.toml
           cat .betterleaks-org-default.toml
 

--- a/workflow-templates/secret-leak-check.yml
+++ b/workflow-templates/secret-leak-check.yml
@@ -13,13 +13,14 @@ jobs:
     uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
     # Optional per-repo overrides. Default behaviour uses the org-wide
     # `default` preset (sensible noise/signal balance) — no input needed.
+    # Available presets live at geolonia/.github/betterleaks/:
+    #   - strict:  every detector on; for PII / payments / prod-cred repos
+    #   - minimal: only highest-signal token-shape detectors
     # with:
-    #   # Pick a stricter or laxer org-wide preset
-    #   # (see geolonia/.github/betterleaks/):
-    #   preset: strict        # every detector on; for PII / payments / prod-cred repos
-    #   preset: minimal       # only highest-signal token-shape detectors
+    #   preset: strict        # or: minimal
     #
-    #   # Or fully custom — supply your own .betterleaks.toml at the repo root:
+    #   # Or fully custom — supply your own .betterleaks.toml at the repo root
+    #   # (takes precedence over `preset`):
     #   config-path: .betterleaks.toml
     #
     #   fail-on-findings: false       # warn-only while cleaning up legacy false positives

--- a/workflow-templates/secret-leak-check.yml
+++ b/workflow-templates/secret-leak-check.yml
@@ -11,8 +11,16 @@ permissions:
 jobs:
   scan:
     uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
-    # Optional per-repo overrides:
+    # Optional per-repo overrides. Default behaviour uses the org-wide
+    # `default` preset (sensible noise/signal balance) — no input needed.
     # with:
-    #   fail-on-findings: false       # warn-only while cleaning up legacy false positives
+    #   # Pick a stricter or laxer org-wide preset
+    #   # (see geolonia/.github/betterleaks/):
+    #   preset: strict        # every detector on; for PII / payments / prod-cred repos
+    #   preset: minimal       # only highest-signal token-shape detectors
+    #
+    #   # Or fully custom — supply your own .betterleaks.toml at the repo root:
     #   config-path: .betterleaks.toml
+    #
+    #   fail-on-findings: false       # warn-only while cleaning up legacy false positives
     #   validate-secrets: false       # active-secret HTTP validation (slower, makes outbound calls)


### PR DESCRIPTION
## Summary

Adds a \`preset\` input to the reusable per-PR secret-leak-check workflow so adopters can pick a stricter or laxer org-wide config without copying a toml file into their repo.

\`\`\`yaml
jobs:
  scan:
    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
    with:
      preset: strict       # or: minimal, default
\`\`\`

Valid values: \`default\` (current behaviour), \`strict\`, \`minimal\`. Unknown presets fail the job with an explicit error. The existing \`config-path\` input still takes precedence for fully custom configs.

## Why

The workflow template only documented \`config-path\` overrides, so users discovering the workflow from the New Workflow UI had no signal that org-wide presets exist. With this change, the workflow-template comments advertise the presets directly and the change-config motion is a single input on the workflow file.

## Test plan

- [ ] CodeRabbit clean
- [ ] After merge, enable the workflow template on a sandbox repo with \`preset: strict\` and confirm the run log shows \`Fetched org preset 'strict'\` and the SHA of the strict.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added ability to select between different security scanning presets (default, strict, minimal) for the secret leak check workflow.

* **Documentation**
  - Updated workflow configuration descriptions to clarify precedence rules and customization options.
  - Added template examples demonstrating preset selection and configuration parameter usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->