### PR TITLE
feat(betterleaks): allowlist JWT-ellipsis + client_id:client_secret literals

### DIFF
--- a/betterleaks/default.toml
+++ b/betterleaks/default.toml
@@ -77,3 +77,21 @@ regexes = [
   '''(?i)\bdev[-_]?local[-_]?token[-_]?please[-_]?change\b''',
   '''(?i)\b(test|sample|dummy|dev|stub)[-_]?(token|key|secret|password)[-_]?(here|value)?\b''',
 ]
+
+[[allowlists]]
+description = "Truncated JWT placeholder in docs (eyJ... ending in literal '...' ellipsis)"
+regexes = [
+  # Matches the docs convention of showing a JWT prefix followed by a
+  # literal three-dot ellipsis. Real JWTs are never written that way.
+  '''eyJ[A-Za-z0-9_\-]{8,}\.\.\.''',
+]
+
+[[allowlists]]
+description = "Basic-auth label pair literal: client_id:client_secret"
+regexes = [
+  # Appears in OAuth docs and test fixtures across the org as the
+  # `-u "client_id:client_secret"` curl flag or
+  # `Buffer.from('client-id:client-secret').toString('base64')` in
+  # tests. Real Basic-auth credentials are never the words themselves.
+  '''(?i)\bclient[-_]id:client[-_]secret\b''',
+]


### PR DESCRIPTION
## Summary

Adds two new \`[[allowlists]]\` entries to the org-wide \`default.toml\`:

- \`eyJ[A-Za-z0-9_\-]{8,}\.\.\.\` — truncated JWT placeholder (eyJ... ending in literal three-dot ellipsis). Real JWTs are never written this way.
- \`(?i)\bclient[-_]id:client[-_]secret\b\` — the label-pair literal used in OAuth Basic-auth docs and test fixtures.

## Origin

geonicdb baseline analysis: 27 findings, **0 real secrets**. Breakdown:

| Pattern | Count |
|---|---:|
| Truncated JWT \`eyJhbGciOiJIUzI1NiIs...\` | 18 |
| \`client_id:client_secret\` / \`client-id:client-secret\` | 7 |
| \`gdb_a1b2c3d4e5f6...\` | 2 (already replaced in current main with angle-bracket form) |

The JWT-ellipsis hits are entirely historical (removed from main). The \`client_id:client_secret\` literal still appears in 3 current files:
- \`docs/INSTRUCTION.md\` (1× curl example)
- \`src/core/auth/oauth/oauth.service.ts\` (1× JSDoc comment)
- \`tests/unit/api/oauth/oauth.controller.test.ts\` (15× test fixtures)

All confirmed false positives. The new allowlist silences them without requiring any change in geonicdb.

## Test plan

- [ ] CodeRabbit clean
- [ ] After merge, a fresh baseline run drops geonicdb to 0 findings (the 27 historical hits all match one of these two patterns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret detection configuration to recognize additional authentication patterns, including JWT prefixes and Basic authentication credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->