### PR TITLE
chore: clean up dogfood consumer wrapper (drop stale preset line)

### DIFF
--- a/.github/workflows/secret-leak-check.yml
+++ b/.github/workflows/secret-leak-check.yml
@@ -11,17 +11,11 @@ permissions:
 jobs:
   scan:
     uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
-    # Optional per-repo overrides. Default behaviour uses the org-wide
-    # `default` preset (sensible noise/signal balance) — no input needed.
-    # Available presets live at geolonia/.github/betterleaks/:
-    #   - strict:  every detector on; for PII / payments / prod-cred repos
-    #   - minimal: only highest-signal token-shape detectors
-    with:
-      preset: strict        # or: minimal
-    #
-    #   # Or fully custom — supply your own .betterleaks.toml at the repo root
-    #   # (takes precedence over `preset`):
+    # The default behaviour scans the PR diff with every betterleaks
+    # detector enabled. If a false positive shows up, commit a
+    # .betterleaks.toml at the repo root with a documented allowlist and
+    # set config-path below.
+    # with:
     #   config-path: .betterleaks.toml
-    #
     #   fail-on-findings: false       # warn-only while cleaning up legacy false positives
     #   validate-secrets: false       # active-secret HTTP validation (slower, makes outbound calls)


### PR DESCRIPTION
## Summary

Follow-up to #35. The dogfood Secret Leak Check workflow in this repo (\`.github/workflows/secret-leak-check.yml\`) had an active \`with: preset: strict\` line that got accidentally uncommented during an earlier edit. With the \`preset\` input removed in #35, that line now produces an "unknown input \`preset\`" warning on every PR scan in this repo (job still passes, but noisy).

This was meant to land in #35 itself but got pushed after the merge, so opening as a separate small PR.

## Test plan

- [ ] CodeRabbit clean
- [ ] After merge: the dogfood scan on the next PR opened here runs without the unknown-input warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the secret-leak scanning workflow configuration to improve documentation of default scanning behavior and false positive suppression options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->