### PR TITLE
fix(workflow-templates): drop "Code scanning" category to avoid GHAS gating

### DIFF
--- a/workflow-templates/secret-leak-check.properties.json
+++ b/workflow-templates/secret-leak-check.properties.json
@@ -2,6 +2,6 @@
   "name": "Secret Leak Check (per PR)",
   "description": "Scan every PR's diff for committed secrets using betterleaks. Blocks the merge check when secrets are detected. Pairs with the weekly org-wide audit in geolonia-operations.",
   "iconName": "shield",
-  "categories": ["Code scanning"],
+  "categories": ["Automation"],
   "filePatterns": []
 }


### PR DESCRIPTION
## Summary

The Secret Leak Check (per PR) workflow template now shows **"Requires GitHub Advanced Security"** in the New Workflow picker, discouraging adoption:

![New Workflow picker showing GHAS requirement]

Cause: in #30 I switched the category from \`Security\` (which didn't render a badge) to \`Code scanning\` (which does). GitHub treats \`Code scanning\` as a GHAS feature in the workflow-template UI on private repos without a GHAS license, hence the banner.

The scanner itself has no GHAS dependency. It runs betterleaks in a regular \`ubuntu-latest\` job and posts plain GitHub Actions annotations.

## Fix

Switch the category to \`Automation\`. It renders a badge in the picker (red dot, matching Geolonia Release and Sync Team Access), and has no feature gating.

This is a regression from #30 -- sorry for the noise.

## Test plan

- [ ] CodeRabbit clean
- [ ] After merge, the New Workflow picker on private repos no longer shows the "Requires GitHub Advanced Security" banner on this template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the categorization of the secret leak check workflow template to better organize it within the available workflow templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->