### PR TITLE
feat(betterleaks): pre-commit-framework template for repos

### DIFF
--- a/betterleaks/.pre-commit-config.example.yaml
+++ b/betterleaks/.pre-commit-config.example.yaml
@@ -1,0 +1,40 @@
+# Example pre-commit-framework config for the Geolonia org.
+#
+# Drop this file at the root of your repository as `.pre-commit-config.yaml`,
+# then run once per laptop:
+#
+#   pip install pre-commit         # or: brew install pre-commit
+#   pre-commit install
+#
+# After that, `git commit` runs Betterleaks on the staged diff and refuses
+# to create the commit if a secret is detected. The same rule set as the
+# per-PR Secret Leak Check, so feedback is consistent between the two.
+#
+# Bypass for the rare case it really needs to commit despite the warning
+# (e.g. you are intentionally adding a test fixture):
+#
+#   git commit --no-verify
+#
+# Server-side enforcement still catches it on the PR if push protection
+# or the per-PR scan are enabled.
+
+repos:
+  - repo: https://github.com/betterleaks/betterleaks
+    # Pin to the same version as the per-PR Secret Leak Check workflow.
+    # Bump both together so local and CI use identical rule shapes.
+    rev: v1.2.0
+    hooks:
+      # Docker variant. Works without a local Go/Rust toolchain. The image
+      # is pulled on first use and cached. Mac/Linux developers typically
+      # already have Docker for the CDK / n8n / Datastore work.
+      - id: betterleaks-docker
+
+      # Alternatives (uncomment one if Docker is not an option):
+      #
+      # `betterleaks` (language: golang) — builds from source. Requires a
+      # local Go toolchain. Fastest after the first build.
+      # - id: betterleaks
+      #
+      # `betterleaks-system` (language: system) — expects the binary on
+      # PATH. Install once with `brew install betterleaks`.
+      # - id: betterleaks-system


### PR DESCRIPTION
## Summary

Adds \`betterleaks/.pre-commit-config.example.yaml\`: an opt-in template that wires the same betterleaks ruleset into each developer's local git workflow.

Once a repo copies this to \`.pre-commit-config.yaml\` and a developer runs \`pre-commit install\` on their laptop, \`git commit\` refuses to create commits containing secrets. Same rules as the per-PR Secret Leak Check, so feedback is consistent before and after pushing.

## Defaults

- Pinned to betterleaks **v1.2.0** (matches the per-PR scan workflow).
- Docker variant by default (no Go/Rust toolchain needed; Mac/Linux devs typically already have Docker for CDK / n8n work).
- Golang and system variants documented as alternatives.

## What this is not

- Not enforced; opt-in per developer (\`pre-commit install\`).
- Bypassable with \`git commit --no-verify\`.
- The per-PR Secret Leak Check on the server side remains the hard gate.

## Test plan

- [ ] CodeRabbit clean
- [ ] After merge, the TechDocs handbook gets a section pointing here (separate PR in geolonia-operations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example pre-commit configuration file to help users set up Betterleaks for automated secret detection during commits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->