### PR TITLE
feat(betterleaks): allowlist build-artifact paths

### DIFF
--- a/betterleaks/default.toml
+++ b/betterleaks/default.toml
@@ -91,3 +91,24 @@ regexes = [
   # tests. Real Basic-auth credentials are never the words themselves.
   '''(?i)\bclient[-_]id:client[-_]secret\b''',
 ]
+
+[[allowlists]]
+description = "Minified bundles, source maps, and webpack bundle-stats output"
+paths = [
+  # Content hashes inside generated build output get flagged as
+  # high-entropy tokens (sourcegraph-access-token in particular fires
+  # on 40-char hex SHA1s, which is exactly what webpack emits as
+  # content-addressing identifiers). We never hand-edit these files,
+  # so anything they contain is by definition not a hand-typed
+  # credential.
+  #
+  # Confirmed false positives by repo in the May 2026 baseline:
+  #   - editor: 21 hits in bundle-stats.json
+  #   - scratch-spacialid: 5 hits in lib.min.js + lib.min.js.map
+  #   - x-geo-scratch: 19 hits in lib.min.js + lib.min.js.map
+  '''\.min\.js$''',
+  '''\.min\.js\.map$''',
+  '''\.min\.css$''',
+  '''\.min\.css\.map$''',
+  '''(?:^|/)bundle-stats\.json$''',
+]


### PR DESCRIPTION
## Summary

Adds a path-based allowlist for minified bundles, source maps, and webpack \`bundle-stats.json\`.

## Why

Content hashes (40-char hex SHA1s) inside generated build output keep tripping the \`sourcegraph-access-token\` rule, which has exactly that shape. These files are never hand-edited, so by definition they don't contain hand-typed credentials.

## Confirmed false positives from the May 2026 baseline

| Repo | Findings | All from |
|---|---:|---|
| editor | 21 | \`bundle-stats.json\` |
| scratch-spacialid | 5 | \`lib.min.js\` + \`.map\` |
| x-geo-scratch | 19 (prior baseline) | \`lib.min.js\` + \`.map\` |

After merge: ~45 findings drop out of the org-wide picture, three repos zero out, and the noise floor lowers further before per-repo issues get drafted.

## What is NOT allowlisted (intentionally)

- \`package-lock.json\` / \`yarn.lock\` — these can legitimately contain real secrets in URLs (e.g. private registry tokens)
- Non-minified \`dist/*\` or \`build/*\` — paths vary too much across repos; rely on per-repo \`.betterleaks.toml\` if needed

## Test plan

- [ ] CodeRabbit clean
- [ ] After merge, the next baseline run shows editor/scratch-spacialid/x-geo-scratch at 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection accuracy by refining the allowlist rules to exclude false positives originating from generated and minified front-end build artifacts. The configuration now effectively filters out common build outputs including minified JavaScript and CSS files, source maps, and bundle statistics files, providing cleaner and more actionable security results for review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->