### PR TITLE
chore(betterleaks): bump v1.2.0 to v1.3.0

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -23,7 +23,7 @@ on:
         description: "betterleaks container image, pinned by digest. Override only for testing newer versions."
         type: string
         required: false
-        default: "ghcr.io/betterleaks/betterleaks@sha256:0d438a2f5821f182bf1af1b2bb74bf3f79830c93291503c1fb90c19cab1ac5d6"  # v1.2.0
+        default: "ghcr.io/betterleaks/betterleaks@sha256:7770e01586febef62452a4042c8c658a5db3e354ecefd36a97c0f322616acab8"  # v1.3.0
       fail-on-findings:
         description: "Fail the job (block the PR check) when secrets are found. Set false for warn-only mode while a repo cleans up legacy false positives."
         type: boolean

--- a/betterleaks/.pre-commit-config.example.yaml
+++ b/betterleaks/.pre-commit-config.example.yaml
@@ -22,7 +22,7 @@ repos:
   - repo: https://github.com/betterleaks/betterleaks
     # Pin to the same version as the per-PR Secret Leak Check workflow.
     # Bump both together so local and CI use identical rule shapes.
-    rev: v1.2.0
+    rev: v1.3.0
     hooks:
       # Docker variant. Works without a local Go/Rust toolchain. The image
       # is pulled on first use and cached. Mac/Linux developers typically


### PR DESCRIPTION
## Summary

Bumps the pinned betterleaks version in both org-wide call sites in this repo from v1.2.0 to v1.3.0:

- `.github/workflows/reusable-secret-leak-check.yml`: default `betterleaks-image` input pinned to the v1.3.0 image digest (`sha256:7770e01586febef62452a4042c8c658a5db3e354ecefd36a97c0f322616acab8`).
- `betterleaks/.pre-commit-config.example.yaml`: `rev: v1.3.0` so freshly-installed pre-commit hooks match the per-PR scanner.

Upstream release: <https://github.com/betterleaks/betterleaks/releases/tag/v1.3.0> (published 2026-05-20, currently marked `isLatest`).

## Out of scope

The org-wide config (`betterleaks/default.toml`) is version-agnostic and stays put.

A companion PR in `geolonia-operations` will bump the weekly cron workflow and the handbook docs, and close the upstream-release tracking issue [`geolonia-operations#95`](https://github.com/geolonia/geolonia-operations/issues/95).

## Test plan

- [x] Manual review of the diff
- [ ] CodeRabbit review
- [ ] After merge, next per-PR `Secret Leak Check` workflow run uses the v1.3.0 image
- [ ] A freshly-installed `.pre-commit-config.example.yaml` instance resolves to the v1.3.0 hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret leak detection tools to version 1.3.0 across continuous integration workflows and local development configurations for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->