### PR TITLE
chore(betterleaks): bump v1.3.0 to v1.3.1

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -23,7 +23,7 @@ on:
         description: "betterleaks container image, pinned by digest. Override only for testing newer versions."
         type: string
         required: false
-        default: "ghcr.io/betterleaks/betterleaks@sha256:7770e01586febef62452a4042c8c658a5db3e354ecefd36a97c0f322616acab8"  # v1.3.0
+        default: "ghcr.io/betterleaks/betterleaks@sha256:0ea9c1f011aa085efd9b27a195f5b70feb91a56fcbbdb8809a345caaf2c7d961"  # v1.3.1
       fail-on-findings:
         description: "Fail the job (block the PR check) when secrets are found. Set false for warn-only mode while a repo cleans up legacy false positives."
         type: boolean

--- a/betterleaks/.pre-commit-config.example.yaml
+++ b/betterleaks/.pre-commit-config.example.yaml
@@ -22,7 +22,7 @@ repos:
   - repo: https://github.com/betterleaks/betterleaks
     # Pin to the same version as the per-PR Secret Leak Check workflow.
     # Bump both together so local and CI use identical rule shapes.
-    rev: v1.3.0
+    rev: v1.3.1
     hooks:
       # Docker variant. Works without a local Go/Rust toolchain. The image
       # is pulled on first use and cached. Mac/Linux developers typically


### PR DESCRIPTION
## Summary

Bumps the betterleaks Docker image pinned in the reusable per-PR secret-leak workflow and the pre-commit example from v1.3.0 to v1.3.1.

- `.github/workflows/reusable-secret-leak-check.yml`: default `betterleaks-image` pinned to the v1.3.1 digest (`sha256:0ea9c1f011aa085efd9b27a195f5b70feb91a56fcbbdb8809a345caaf2c7d961`).
- `betterleaks/.pre-commit-config.example.yaml`: `rev: v1.3.0` to `rev: v1.3.1`.

Upstream release: https://github.com/betterleaks/betterleaks/releases/tag/v1.3.1.

Companion to [geolonia/geolonia-operations#107](https://github.com/geolonia/geolonia-operations/pull/107), which bumps the weekly org-wide audit. Mirrors the previous v1.2.0 -> v1.3.0 split (this repo #40 + operations #103).

Closes #41.

## Test plan

- [x] Verified v1.3.1 digest via `docker pull ghcr.io/betterleaks/betterleaks:v1.3.1` + `docker inspect --format='{{index .RepoDigests 0}}'`.
- [ ] CI: workflow file is valid YAML on push.
- [ ] After merge, the next per-PR secret-leak check in any consumer repo runs against v1.3.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Betterleaks security scanning tool from v1.3.1 to v1.3.1 in workflow configurations and pre-commit example settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->