### PR TITLE
chore(betterleaks): revert v1.3.1 to v1.3.0 (amd64 crash)

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -23,7 +23,7 @@ on:
         description: "betterleaks container image, pinned by digest. Override only for testing newer versions."
         type: string
         required: false
-        default: "ghcr.io/betterleaks/betterleaks@sha256:0ea9c1f011aa085efd9b27a195f5b70feb91a56fcbbdb8809a345caaf2c7d961"  # v1.3.1
+        default: "ghcr.io/betterleaks/betterleaks@sha256:7770e01586febef62452a4042c8c658a5db3e354ecefd36a97c0f322616acab8"  # v1.3.0 -- v1.3.1 crashes on linux/amd64 (Go 1.25 taggedPointerPack bug). Revert until upstream ships v1.3.2.
       fail-on-findings:
         description: "Fail the job (block the PR check) when secrets are found. Set false for warn-only mode while a repo cleans up legacy false positives."
         type: boolean

--- a/betterleaks/.pre-commit-config.example.yaml
+++ b/betterleaks/.pre-commit-config.example.yaml
@@ -22,7 +22,7 @@ repos:
   - repo: https://github.com/betterleaks/betterleaks
     # Pin to the same version as the per-PR Secret Leak Check workflow.
     # Bump both together so local and CI use identical rule shapes.
-    rev: v1.3.1
+    rev: v1.3.0
     hooks:
       # Docker variant. Works without a local Go/Rust toolchain. The image
       # is pulled on first use and cached. Mac/Linux developers typically


### PR DESCRIPTION
## Summary

The v1.3.1 betterleaks image was rebuilt with Go 1.25, which has a known runtime panic on linux/amd64:

\`\`\`
fatal error: taggedPointerPack
runtime: taggedPointerPack invalid packing: ptr=0xffff... tag=0x1 packed=0xffff...0001 -> ptr=0xffffffff... tag=0x1
\`\`\`

GitHub \`ubuntu-latest\` runners are linux/amd64, so **every per-PR secret-leak scan across every consumer repo is failing** since v1.13.1 shipped (~22:00 UTC). First victim spotted: [geolonia-backstage#167 / run 26373916341](https://github.com/geolonia/geolonia-backstage/actions/runs/26373916341).

Reproduced locally with \`docker run --rm --platform linux/amd64 ghcr.io/betterleaks/betterleaks:v1.3.1 version\` — same panic. v1.3.0 with the same command exits 0.

This PR reverts the digest pinned in \`reusable-secret-leak-check.yml\` and the \`rev:\` in the pre-commit example back to v1.3.0. Once upstream cuts v1.3.2 with a fixed Go runtime we can re-bump.

Reverts the change shipped in #42.

## Test plan

- [x] Reproduced the amd64 crash locally on v1.3.1; confirmed v1.3.0 still works.
- [ ] After merge, tag \`v1.13.2\` so the auto-release moves \`v1\` / \`v1.13\` back to a v1.3.0 default.
- [ ] Verify the next per-PR secret-leak check on any consumer repo passes.
- [ ] File upstream issue at \`betterleaks/betterleaks\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reverted container image for secret leak checking
  * Updated pre-commit hook configuration to version 1.3.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->