### PR TITLE
feat(workflows): add Bumblebee supply-chain scan (reusable + template)

### DIFF
--- a/.github/workflows/reusable-bumblebee-scan.yml
+++ b/.github/workflows/reusable-bumblebee-scan.yml
@@ -1,27 +1,17 @@
 name: "[REUSABLE] Bumblebee Supply-Chain Scan"
 
-# Per-PR (and push-to-main) supply-chain inventory scan. Bumblebee
-# (Apache-2.0, by Perplexity) inventories installed packages across
+# Per-PR (and push-to-main) supply-chain inventory scan using
+# Bumblebee (Apache-2.0). Matches installed packages across
 # npm/pypi/go/rubygems/composer/mcp/editor-extension/browser-extension
-# and matches them against curated exposure catalogs (`threat_intel/`)
-# shipped in the same upstream release.
+# against curated `threat_intel/` exposure catalogs shipped in the
+# same upstream release.
 #
-# Complements:
-#   - betterleaks (PR diff secret scan) — different surface (commits)
-#   - Dependabot (CVEs in declared deps) — different signal (CVEs vs IOCs)
-#   - CodeRabbit (PR diff review) — different scope (source vs deps)
-#
-# Initial trial scoped to geolonia-backstage; see geolonia-operations#109
-# for the rollout plan.
-#
-# Consumer wrapper (in any repo):
+# Consumer wrapper:
 #
 #   name: Bumblebee Scan
 #   on:
-#     pull_request:
-#       branches: [main]
-#     push:
-#       branches: [main]
+#     pull_request: { branches: [main] }
+#     push: { branches: [main] }
 #   permissions:
 #     contents: read
 #     pull-requests: write
@@ -33,12 +23,12 @@ on:
   workflow_call:
     inputs:
       bumblebee-version:
-        description: "Bumblebee release tag (also the source for `threat_intel/`). Default tracks the version evaluated in geolonia-operations#109."
+        description: "Bumblebee release tag (also the source for `threat_intel/`)."
         type: string
         required: false
         default: "v0.1.1"
       fail-on-findings:
-        description: "Fail the job (block the PR check) when exposures are matched. Set false for warn-only mode while triaging."
+        description: "Fail the job when exposures are matched. Set false for warn-only mode."
         type: boolean
         required: false
         default: true
@@ -48,18 +38,18 @@ on:
         required: false
         default: ""
       profile:
-        description: "Scan profile: baseline, project, or deep. `project` is the right default for CI on a repo checkout."
+        description: "Scan profile: baseline, project, or deep."
         type: string
         required: false
         default: "project"
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: read        # checkout the repository
+  pull-requests: write  # post/update PR comment with scan results
 
 jobs:
   scan:
-    name: bumblebee (project scan)
+    name: bumblebee (${{ inputs.profile }} scan)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -73,17 +63,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BUMBLEBEE_VERSION: ${{ inputs.bumblebee-version }}
         run: |
-          # Pin to a specific release. The tarball ships both the
-          # `bumblebee` binary and the `threat_intel/` catalog, so a
-          # single download covers both. We verify against the
-          # published checksums.txt before extracting.
           mkdir -p .bumblebee && cd .bumblebee
           ASSET="bumblebee_${BUMBLEBEE_VERSION#v}_linux_amd64.tar.gz"
           gh release download "${BUMBLEBEE_VERSION}" \
             -R perplexityai/bumblebee \
             -p "${ASSET}" \
             -p "checksums.txt"
-          shasum -a 256 -c <(grep "linux_amd64" checksums.txt)
+          shasum -a 256 -c <(grep "${ASSET}" checksums.txt)
           tar -xzf "${ASSET}"
           ./bumblebee version
 
@@ -120,19 +106,14 @@ jobs:
             echo "scan_failed=true" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          # NDJSON: one JSON record per line. Each finding is
-          # record_type=finding. With --findings-only, the file
-          # contains only findings + a trailing scan_summary.
           TOTAL=$(grep -c '"record_type":"finding"' bumblebee-findings.ndjson || true)
           echo "total=${TOTAL:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Emit inline annotations
         if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0'
         run: |
-          # One ::error:: workflow command per finding. Sanitize every
-          # interpolated field (newlines, `::`) to prevent
-          # workflow-command injection from a maliciously named
-          # package or catalog entry.
+          # Sanitize interpolated fields (newlines, `::`) to prevent
+          # workflow-command injection from a maliciously named package.
           grep '"record_type":"finding"' bumblebee-findings.ndjson | jq -r '
             def safe: tostring | gsub("[\r\n]"; " ") | gsub("::"; "[colon-colon]");
             "::error file=" + ((.source_file // "(unknown)") | safe) +
@@ -184,7 +165,7 @@ jobs:
               echo "Full NDJSON report attached to the [workflow run](${RUN_URL}) as an artifact."
               if [ "${FAIL_ON_FINDINGS}" = "true" ]; then
                 echo ""
-                echo "**This check is failing the PR.** A matched package is a known supply-chain compromise — treat as incident response, not a routine dependency issue."
+                echo "**This check is failing the PR.** A matched package is a known supply-chain compromise — treat as incident response."
               else
                 echo ""
                 echo "_This check is in warn-only mode (\`fail-on-findings: false\`)._"
@@ -195,10 +176,8 @@ jobs:
           echo "marker=${MARKER}" >> "$GITHUB_OUTPUT"
 
       - name: Post / update PR comment
-        # PRs from forks (and Dependabot PRs) get a read-only
-        # GITHUB_TOKEN regardless of the `permissions:` block. This
-        # step degrades gracefully in that case — annotations + the
-        # artifact still carry the report.
+        # GITHUB_TOKEN is read-only on fork PRs / Dependabot PRs. Degrade
+        # gracefully — annotations + artifact still carry the report.
         if: always() && github.event.pull_request.number != null
         continue-on-error: true
         env:

--- a/.github/workflows/reusable-bumblebee-scan.yml
+++ b/.github/workflows/reusable-bumblebee-scan.yml
@@ -70,7 +70,7 @@ jobs:
             -R perplexityai/bumblebee \
             -p "${ASSET}" \
             -p "checksums.txt"
-          shasum -a 256 -c <(grep "${ASSET}" checksums.txt)
+          shasum -a 256 -c <(grep -F "${ASSET}" checksums.txt)
           tar -xzf "${ASSET}"
           ./bumblebee version
 

--- a/.github/workflows/reusable-bumblebee-scan.yml
+++ b/.github/workflows/reusable-bumblebee-scan.yml
@@ -1,0 +1,248 @@
+name: "[REUSABLE] Bumblebee Supply-Chain Scan"
+
+# Per-PR (and push-to-main) supply-chain inventory scan. Bumblebee
+# (Apache-2.0, by Perplexity) inventories installed packages across
+# npm/pypi/go/rubygems/composer/mcp/editor-extension/browser-extension
+# and matches them against curated exposure catalogs (`threat_intel/`)
+# shipped in the same upstream release.
+#
+# Complements:
+#   - betterleaks (PR diff secret scan) — different surface (commits)
+#   - Dependabot (CVEs in declared deps) — different signal (CVEs vs IOCs)
+#   - CodeRabbit (PR diff review) — different scope (source vs deps)
+#
+# Initial trial scoped to geolonia-backstage; see geolonia-operations#109
+# for the rollout plan.
+#
+# Consumer wrapper (in any repo):
+#
+#   name: Bumblebee Scan
+#   on:
+#     pull_request:
+#       branches: [main]
+#     push:
+#       branches: [main]
+#   permissions:
+#     contents: read
+#     pull-requests: write
+#   jobs:
+#     scan:
+#       uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@v1
+
+on:
+  workflow_call:
+    inputs:
+      bumblebee-version:
+        description: "Bumblebee release tag (also the source for `threat_intel/`). Default tracks the version evaluated in geolonia-operations#109."
+        type: string
+        required: false
+        default: "v0.1.1"
+      fail-on-findings:
+        description: "Fail the job (block the PR check) when exposures are matched. Set false for warn-only mode while triaging."
+        type: boolean
+        required: false
+        default: true
+      ecosystems:
+        description: "Comma-separated ecosystems to scan (npm,pypi,go,rubygems,packagist,mcp,editor-extension,browser-extension). Empty = all."
+        type: string
+        required: false
+        default: ""
+      profile:
+        description: "Scan profile: baseline, project, or deep. `project` is the right default for CI on a repo checkout."
+        type: string
+        required: false
+        default: "project"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    name: bumblebee (project scan)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download bumblebee binary + threat_intel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUMBLEBEE_VERSION: ${{ inputs.bumblebee-version }}
+        run: |
+          # Pin to a specific release. The tarball ships both the
+          # `bumblebee` binary and the `threat_intel/` catalog, so a
+          # single download covers both. We verify against the
+          # published checksums.txt before extracting.
+          mkdir -p .bumblebee && cd .bumblebee
+          ASSET="bumblebee_${BUMBLEBEE_VERSION#v}_linux_amd64.tar.gz"
+          gh release download "${BUMBLEBEE_VERSION}" \
+            -R perplexityai/bumblebee \
+            -p "${ASSET}" \
+            -p "checksums.txt"
+          shasum -a 256 -c <(grep "linux_amd64" checksums.txt)
+          tar -xzf "${ASSET}"
+          ./bumblebee version
+
+      - name: Run bumblebee scan
+        id: scan
+        continue-on-error: true
+        env:
+          ECOSYSTEMS: ${{ inputs.ecosystems }}
+          PROFILE: ${{ inputs.profile }}
+        run: |
+          args=(
+            scan
+            --profile "${PROFILE}"
+            --root "${GITHUB_WORKSPACE}"
+            --exposure-catalog .bumblebee/threat_intel
+            --findings-only
+            --output file
+            --output-file bumblebee-findings.ndjson
+            --max-duration 10m
+          )
+          if [ -n "${ECOSYSTEMS}" ]; then
+            args+=(--ecosystem "${ECOSYSTEMS}")
+          fi
+          ./.bumblebee/bumblebee "${args[@]}"
+
+      - name: Count findings
+        id: findings
+        if: always()
+        env:
+          SCAN_OUTCOME: ${{ steps.scan.outcome }}
+        run: |
+          if [ ! -f bumblebee-findings.ndjson ]; then
+            echo "::error::bumblebee did not produce an output file (outcome=${SCAN_OUTCOME})"
+            echo "scan_failed=true" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          # NDJSON: one JSON record per line. Each finding is
+          # record_type=finding. With --findings-only, the file
+          # contains only findings + a trailing scan_summary.
+          TOTAL=$(grep -c '"record_type":"finding"' bumblebee-findings.ndjson || true)
+          echo "total=${TOTAL:-0}" >> "$GITHUB_OUTPUT"
+
+      - name: Emit inline annotations
+        if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0'
+        run: |
+          # One ::error:: workflow command per finding. Sanitize every
+          # interpolated field (newlines, `::`) to prevent
+          # workflow-command injection from a maliciously named
+          # package or catalog entry.
+          grep '"record_type":"finding"' bumblebee-findings.ndjson | jq -r '
+            def safe: tostring | gsub("[\r\n]"; " ") | gsub("::"; "[colon-colon]");
+            "::error file=" + ((.source_file // "(unknown)") | safe) +
+            "::Bumblebee finding: " + ((.ecosystem // "?") | safe) +
+            " package " + ((.package_name // "?") | safe) +
+            "@" + ((.version // "?") | safe) +
+            " matches catalog " + ((.catalog_id // "?") | safe) +
+            " (severity " + ((.severity // "unspecified") | safe) +
+            ", confidence " + ((.confidence // "?") | safe) + ")"
+          '
+
+      - name: Build PR comment body
+        id: comment
+        if: always()
+        env:
+          SCAN_FAILED: ${{ steps.findings.outputs.scan_failed }}
+          TOTAL: ${{ steps.findings.outputs.total }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+          BUMBLEBEE_VERSION: ${{ inputs.bumblebee-version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY_FILE="pr-comment.md"
+          MARKER="<!-- bumblebee-reusable-v1 -->"
+          {
+            echo "${MARKER}"
+            echo ""
+            echo "### Bumblebee Supply-Chain Scan (\`${BUMBLEBEE_VERSION}\`)"
+            echo ""
+            if [ "${SCAN_FAILED}" = "true" ]; then
+              echo "X Bumblebee scan failed before producing a readable report. [Workflow run](${RUN_URL})"
+            elif [ "${TOTAL:-0}" = "0" ]; then
+              echo "OK No exposure-catalog matches in this checkout."
+            else
+              DETAILS=$(grep '"record_type":"finding"' bumblebee-findings.ndjson | jq -r '
+                "- **" + (.severity // "unspecified") + "** `" +
+                (.ecosystem // "?") + ":" + (.package_name // "?") + "@" + (.version // "?") +
+                "` matches `" + (.catalog_id // "?") + "`" +
+                (if .source_file then " at `" + .source_file + "`" else "" end) +
+                " — " + (.evidence // "exact match")
+              ')
+              MAX=60000
+              if [ "${#DETAILS}" -gt "${MAX}" ]; then
+                DETAILS="${DETAILS:0:${MAX}}"$'\n\n_(Truncated; full NDJSON in the workflow artifact.)_'
+              fi
+              echo "Found **${TOTAL} exposure match(es)** against upstream \`threat_intel/\`."
+              echo ""
+              echo "${DETAILS}"
+              echo ""
+              echo "Full NDJSON report attached to the [workflow run](${RUN_URL}) as an artifact."
+              if [ "${FAIL_ON_FINDINGS}" = "true" ]; then
+                echo ""
+                echo "**This check is failing the PR.** A matched package is a known supply-chain compromise — treat as incident response, not a routine dependency issue."
+              else
+                echo ""
+                echo "_This check is in warn-only mode (\`fail-on-findings: false\`)._"
+              fi
+            fi
+          } > "${BODY_FILE}"
+          echo "body_file=${BODY_FILE}" >> "$GITHUB_OUTPUT"
+          echo "marker=${MARKER}" >> "$GITHUB_OUTPUT"
+
+      - name: Post / update PR comment
+        # PRs from forks (and Dependabot PRs) get a read-only
+        # GITHUB_TOKEN regardless of the `permissions:` block. This
+        # step degrades gracefully in that case — annotations + the
+        # artifact still carry the report.
+        if: always() && github.event.pull_request.number != null
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BODY_FILE: ${{ steps.comment.outputs.body_file }}
+          MARKER: ${{ steps.comment.outputs.marker }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --slurp \
+            --jq "[.[].[] | select(.body | startswith(env.MARKER))] | .[0].id // empty" \
+            2>/dev/null || true)
+          if [ -n "${EXISTING}" ]; then
+            if gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+                 -f body="$(cat "${BODY_FILE}")" >/dev/null 2>&1; then
+              echo "Updated existing bumblebee comment (#${EXISTING})."
+            else
+              echo "::warning::Could not update PR comment (read-only token in fork PR / Dependabot context)."
+            fi
+          else
+            if gh pr comment "${PR_NUMBER}" --body-file "${BODY_FILE}" >/dev/null 2>&1; then
+              echo "Posted new bumblebee comment."
+            else
+              echo "::warning::Could not post PR comment (read-only token in fork PR / Dependabot context)."
+            fi
+          fi
+
+      - name: Upload findings as artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bumblebee-findings-${{ github.event.pull_request.number || github.run_id }}
+          path: bumblebee-findings.ndjson
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Fail the job if findings + fail-on-findings
+        if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0' && inputs.fail-on-findings == true
+        run: |
+          echo "::error::Bumblebee scan failed: ${{ steps.findings.outputs.total }} exposure match(es) found."
+          exit 1
+
+      - name: Surface scan-level failure
+        if: always() && steps.findings.outputs.scan_failed == 'true'
+        run: |
+          echo "::error::Bumblebee scan failed before producing a readable report."
+          exit 1

--- a/.github/workflows/reusable-bumblebee-scan.yml
+++ b/.github/workflows/reusable-bumblebee-scan.yml
@@ -223,6 +223,15 @@ jobs:
           MARKER="<!-- bumblebee-finding-issue-v1 -->"
           TITLE="Bumblebee: ${TOTAL} supply-chain finding(s) detected"
 
+          # Reuse the PR-comment body but swap its marker for the
+          # issue-specific one, so the idempotent lookup below
+          # actually finds issues we created earlier.
+          ISSUE_BODY_FILE="issue-body.md"
+          {
+            echo "${MARKER}"
+            tail -n +2 "${BODY_FILE}"
+          } > "${ISSUE_BODY_FILE}"
+
           gh label create bumblebee-finding --color "b60205" \
             --description "Bumblebee supply-chain scan match — investigate as incident response" \
             --repo "${{ github.repository }}" 2>/dev/null || true
@@ -241,7 +250,7 @@ jobs:
             gh issue edit "${EXISTING}" \
               --repo "${{ github.repository }}" \
               --title "${TITLE}" \
-              --body-file "${BODY_FILE}"
+              --body-file "${ISSUE_BODY_FILE}"
             gh issue comment "${EXISTING}" \
               --repo "${{ github.repository }}" \
               --body "Re-detected in [${EVENT_NAME} run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) — ${TOTAL} finding(s)."
@@ -252,7 +261,7 @@ jobs:
               --title "${TITLE}" \
               --label bumblebee-finding \
               --label security \
-              --body-file "${BODY_FILE}"
+              --body-file "${ISSUE_BODY_FILE}"
             echo "Opened new tracking issue."
           fi
 

--- a/.github/workflows/reusable-bumblebee-scan.yml
+++ b/.github/workflows/reusable-bumblebee-scan.yml
@@ -46,6 +46,7 @@ on:
 permissions:
   contents: read        # checkout the repository
   pull-requests: write  # post/update PR comment with scan results
+  issues: write         # open/update a tracking issue on non-PR triggers (schedule, release, workflow_dispatch)
 
 jobs:
   scan:
@@ -203,6 +204,56 @@ jobs:
             else
               echo "::warning::Could not post PR comment (read-only token in fork PR / Dependabot context)."
             fi
+          fi
+
+      - name: Open / update tracking issue (non-PR triggers)
+        # On schedule / workflow_dispatch / release / push, there's no
+        # PR to comment on. Open one tracking issue per repo (label
+        # `bumblebee-finding`), updating it idempotently via a marker
+        # so re-runs don't spam.
+        if: always() && github.event.pull_request.number == null && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BODY_FILE: ${{ steps.comment.outputs.body_file }}
+          TOTAL: ${{ steps.findings.outputs.total }}
+          BUMBLEBEE_VERSION: ${{ inputs.bumblebee-version }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          MARKER="<!-- bumblebee-finding-issue-v1 -->"
+          TITLE="Bumblebee: ${TOTAL} supply-chain finding(s) detected"
+
+          gh label create bumblebee-finding --color "b60205" \
+            --description "Bumblebee supply-chain scan match — investigate as incident response" \
+            --repo "${{ github.repository }}" 2>/dev/null || true
+          gh label create security --color "ee0701" \
+            --description "Security-related issue" \
+            --repo "${{ github.repository }}" 2>/dev/null || true
+
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label bumblebee-finding \
+            --state open \
+            --json number,body \
+            --jq "[.[] | select(.body | startswith(\"${MARKER}\"))] | .[0].number // empty")
+
+          if [ -n "${EXISTING}" ]; then
+            gh issue edit "${EXISTING}" \
+              --repo "${{ github.repository }}" \
+              --title "${TITLE}" \
+              --body-file "${BODY_FILE}"
+            gh issue comment "${EXISTING}" \
+              --repo "${{ github.repository }}" \
+              --body "Re-detected in [${EVENT_NAME} run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) — ${TOTAL} finding(s)."
+            echo "Updated existing tracking issue #${EXISTING}."
+          else
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "${TITLE}" \
+              --label bumblebee-finding \
+              --label security \
+              --body-file "${BODY_FILE}"
+            echo "Opened new tracking issue."
           fi
 
       - name: Upload findings as artifact

--- a/workflow-templates/bumblebee-scan.properties.json
+++ b/workflow-templates/bumblebee-scan.properties.json
@@ -3,5 +3,12 @@
   "description": "Scan installed packages (npm, pypi, go, rubygems, composer, MCP servers, editor and browser extensions) against curated supply-chain exposure catalogs. Fails the PR if a known-compromised package is detected.",
   "iconName": "lock",
   "categories": ["Security", "Automation"],
-  "filePatterns": ["package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "go.mod", "Gemfile", "composer.json", ".mcp.json"]
+  "filePatterns": [
+    "package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb",
+    "pyproject.toml", "requirements.txt", "poetry.lock", "Pipfile.lock",
+    "go.mod",
+    "Gemfile",
+    "composer.json",
+    ".mcp.json"
+  ]
 }

--- a/workflow-templates/bumblebee-scan.properties.json
+++ b/workflow-templates/bumblebee-scan.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Bumblebee Supply-Chain Scan",
+  "description": "Scan installed packages (npm, pypi, go, rubygems, composer, MCP servers, editor and browser extensions) against curated supply-chain exposure catalogs. Fails the PR if a known-compromised package is detected.",
+  "iconName": "lock",
+  "categories": ["Security", "Automation"],
+  "filePatterns": ["package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "go.mod", "Gemfile", "composer.json", ".mcp.json"]
+}

--- a/workflow-templates/bumblebee-scan.yml
+++ b/workflow-templates/bumblebee-scan.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   scan:

--- a/workflow-templates/bumblebee-scan.yml
+++ b/workflow-templates/bumblebee-scan.yml
@@ -3,8 +3,14 @@ name: Bumblebee Scan
 on:
   pull_request:
     branches: [$default-branch]
-  push:
-    branches: [$default-branch]
+  schedule:
+    # 19:00 UTC = 04:00 JST. Catches packages that become IOCs after
+    # merge — the exposure catalog updates independently of your code.
+    - cron: "0 19 * * *"
+  workflow_dispatch:
+  # Uncomment for repos that publish artifacts (npm / PyPI / Docker):
+  # release:
+  #   types: [published]
 
 permissions:
   contents: read

--- a/workflow-templates/bumblebee-scan.yml
+++ b/workflow-templates/bumblebee-scan.yml
@@ -1,0 +1,22 @@
+name: Bumblebee Scan
+
+on:
+  pull_request:
+    branches: [$default-branch]
+  push:
+    branches: [$default-branch]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@v1
+    # Default: project profile, all ecosystems, fail PR on any match.
+    # Common overrides:
+    # with:
+    #   ecosystems: "npm,mcp"            # scope to specific ecosystems
+    #   fail-on-findings: false          # warn-only while triaging
+    #   bumblebee-version: "v0.1.1"      # pin a different release
+    #   profile: "baseline"              # baseline | project | deep


### PR DESCRIPTION
## Summary

Adds two coupled pieces for running [Bumblebee](https://github.com/perplexityai/bumblebee) (Apache-2.0) in repo CI:

1. **`reusable-bumblebee-scan.yml`** — reusable workflow that downloads the pinned upstream binary + `threat_intel/` catalogs, scans the repo checkout, posts an idempotent PR comment, uploads the NDJSON as an artifact, and fails the check on any match.
2. **`workflow-templates/bumblebee-scan.{yml,properties.json}`** — exposes (1) under the **Security / Automation** categories in the "New workflow" UI of every repo in the org, so it can be enabled per-repo with one click.

## Why

Existing CI surface — secret scanning, Dependabot CVEs, source review — does not detect packages known to have been *compromised or weaponized* in the wild. Bumblebee fills that gap and also adds coverage for MCP servers and editor/browser extensions.

## Design notes

- Pulls `threat_intel/` directly from the upstream release tarball at the pinned tag — no mirror.
- Checksum verified before extraction (`shasum -a 256 -c`).
- Patterns lifted from `reusable-secret-leak-check.yml`: SHA-pinned actions, idempotent PR comment via marker, inline `::error::` annotations sanitized against workflow-command injection, artifact upload, graceful fork/Dependabot fallback when `GITHUB_TOKEN` is read-only.

## Inputs

| Input | Default | Purpose |
|---|---|---|
| `bumblebee-version` | `v0.1.1` | Upstream release tag — also the source for `threat_intel/` |
| `fail-on-findings` | `true` | Warn-only mode possible for triage |
| `ecosystems` | (all) | Optional comma list to scope, e.g. `npm,mcp` |
| `profile` | `project` | One of `baseline`/`project`/`deep` |

## Consumer wrapper

```yaml
name: Bumblebee Scan
on:
  pull_request: { branches: [main] }
  push: { branches: [main] }
permissions:
  contents: read
  pull-requests: write
jobs:
  scan:
    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@v1
```

## Test plan

- [ ] CodeRabbit review clean
- [ ] After merge: tag `v1.14.0` (auto-release workflow moves `v1` / `v1.14`)
- [ ] Add the template to a downstream repo via the "New workflow" UI and verify: scan completes <2 min, "no matches" comment posts, NDJSON artifact uploads
- [ ] Verify on a deliberately-poisoned fixture branch (planted IOC name+version): scan fails the check, annotations + PR comment list the finding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable supply‑chain scan workflow that runs Bumblebee, verifies release integrity, produces and uploads a findings artifact, emits workflow annotations for matches, and can optionally fail the run when configured.
* **New Features**
  * Added a ready‑to‑use "Bumblebee Scan" workflow template and metadata/template registration to run on PRs, nightly schedules, or manual dispatch and post/update an idempotent summarized comment or tracking issue with truncated evidence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/.github/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->