### PR TITLE
chore(secret-leak-check): bump betterleaks default to v1.4.1

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -23,7 +23,7 @@ on:
         description: "betterleaks container image, pinned by digest. Override only for testing newer versions."
         type: string
         required: false
-        default: "ghcr.io/betterleaks/betterleaks@sha256:7770e01586febef62452a4042c8c658a5db3e354ecefd36a97c0f322616acab8"  # v1.3.0 -- v1.3.1 crashes on linux/amd64 (Go 1.25 taggedPointerPack bug). Revert until upstream ships v1.3.2.
+        default: "ghcr.io/betterleaks/betterleaks@sha256:1edd658874fbbd42fe224b7b0ccff32acc5940dd0098ad651caf32998462bff7"  # v1.4.1 -- fixes the Go 1.25 taggedPointerPack crash on linux/amd64 that affected v1.3.1..v1.4.0.
       fail-on-findings:
         description: "Fail the job (block the PR check) when secrets are found. Set false for warn-only mode while a repo cleans up legacy false positives."
         type: boolean


### PR DESCRIPTION
## What

Bump the `reusable-secret-leak-check.yml` default betterleaks image from v1.3.0 to **v1.4.1**, pinned by the multi-arch index digest `sha256:1edd6588...62bff7`.

## Why

v1.3.1 through v1.4.0 were rebuilt with Go 1.25.0 and crashed on linux/amd64 with a `taggedPointerPack` runtime panic, which forced the revert to v1.3.0. Upstream's v1.4.1 fixes the Go toolchain issue.

## Verification

```
$ docker run --rm --platform linux/amd64 ghcr.io/betterleaks/betterleaks:v1.4.1 version
1.4.1
```

Runs clean on amd64 (exit 0, no panic). Index digest covers linux/amd64 + linux/arm64.

Callers pinning `@v1` (e.g. the per-repo PR-time secret-leak check) pick this up once the release tag moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the secret leak detection tool to a newer version for enhanced scanning capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->