### PR TITLE
Add reusable Action Pinning Check (pinact) + canonical config

### DIFF
--- a/.github/workflows/reusable-pinact-check.yml
+++ b/.github/workflows/reusable-pinact-check.yml
@@ -1,0 +1,60 @@
+name: "[REUSABLE] Action Pinning Check"
+
+# Per-PR gate that verifies every GitHub Action and reusable workflow
+# referenced in the caller repo is:
+#
+#   1. pinned to a full 40-char commit SHA,
+#   2. annotated with a version comment that matches that SHA, and
+#   3. at least the minimum release age set in the repo's .pinact.yml
+#      (org default: 7 days).
+#
+# It runs pinact in validation-only mode (fix: false): it never edits a
+# file or pushes a commit, it only fails the check when something is off.
+# Pair it with a repo-root .pinact.yml and Dependabot (github-actions,
+# weekly, with a matching cooldown) so pins stay current without manual
+# SHA edits.
+#
+# Consumer wrapper (in any repo):
+#
+#   name: Action Pinning Check
+#   on:
+#     pull_request:
+#       branches: [main]
+#   jobs:
+#     pinact:
+#       uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@v1
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner label for the check job."
+        type: string
+        required: false
+        default: "ubuntu-latest"
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    name: pinact (verify pins)
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify action pins
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a  # v3.0.0
+        with:
+          # Validation only: pinact reports problems and exits non-zero,
+          # but never rewrites workflows or pushes a fix from CI.
+          fix: "false"
+          # --verify-comment: the version comment must match the pinned SHA.
+          verify: "true"
+          # --verify-min-age: enforce the .pinact.yml minimum release age
+          # against the currently pinned versions.
+          verify_min_age: "true"

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -129,6 +129,74 @@ picker, look under **By Geolonia** for **Bumblebee Supply-Chain Scan**
 and click **Configure**. Commit the file as suggested. No other setup
 is required.
 
+## Action Pinning Check (`reusable-pinact-check.yml`)
+
+- Runs on `pull_request` to the default branch.
+- Delegates to `reusable-pinact-check.yml@v1`, which runs
+  [pinact](https://github.com/suzuki-shunsuke/pinact) (via
+  `suzuki-shunsuke/pinact-action`) in validation-only mode (`fix: false`):
+  it never edits a file or pushes a commit, it only fails the check.
+- Fails the PR when any GitHub Action or reusable workflow is not pinned
+  to a full commit SHA, when a version comment does not match the pinned
+  SHA, or when a pinned release is younger than the minimum release age.
+
+The org standard is to pin every action to a 40-char commit SHA with a
+matching version comment, for example
+`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2`.
+SHA pins are immutable, so a hijacked upstream tag cannot silently change
+what runs in CI. Dependabot keeps the pins current.
+
+Example minimal usage:
+
+```yaml
+name: Action Pinning Check
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  pinact:
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@v1
+```
+
+### Prerequisites
+
+Two files at the repo root, both copyable from `geolonia/.github`:
+
+1. **`.pinact.yml`** (copy `pinact/.pinact.yml`): sets the minimum
+   release age (org default: 7 days, `min_age.value: 7`, `always: true`).
+   This is the GitHub Actions analog of pnpm's `minimumReleaseAge`: a new
+   tag is not adopted until it has survived a week, the window when a
+   hijacked-tag attack is most likely to still be live.
+2. **`.github/dependabot.yml`** with a `github-actions` ecosystem entry,
+   `cooldown: { default-days: 7 }` (matches the pinact min age), and a
+   `groups` block batching minor/patch bumps into one PR while majors
+   arrive individually. Dependabot bumps the SHA and the version comment
+   together, so pins never go stale.
+
+### Inputs
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `runs-on` | `ubuntu-latest` | Runner label for the check job. |
+
+### Local pre-commit (optional but recommended)
+
+Install the [pre-commit](https://pre-commit.com/) hook so pins are
+applied and the min-age is enforced before you push, instead of finding
+out from a red CI check. Copy `pinact/.pre-commit-config.example.yaml`
+from `geolonia/.github` to `.pre-commit-config.yaml`, install pinact
+(`brew install pinact`), then `pre-commit install`.
+
+### Adding it to a repo
+
+1. Copy `.pinact.yml` and the Dependabot config (see Prerequisites).
+2. Open the repo on GitHub and go to **Actions -> New workflow**. Under
+   **By Geolonia**, pick **Action Pinning Check** and **Configure**.
+3. Run `pinact run` once locally (or let the pre-commit hook do it) to
+   SHA-pin existing workflows, then commit.
+
 ## Updating templates
 
 - Keep the `.properties.json` metadata in sync with the YAML so the workflow

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -160,7 +160,7 @@ jobs:
     uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@v1
 ```
 
-### Prerequisites
+### Required files
 
 Two files at the repo root, both copyable from `geolonia/.github`:
 
@@ -175,7 +175,7 @@ Two files at the repo root, both copyable from `geolonia/.github`:
    arrive individually. Dependabot bumps the SHA and the version comment
    together, so pins never go stale.
 
-### Inputs
+### Check inputs
 
 | Input | Default | Purpose |
 | --- | --- | --- |
@@ -189,9 +189,9 @@ out from a red CI check. Copy `pinact/.pre-commit-config.example.yaml`
 from `geolonia/.github` to `.pre-commit-config.yaml`, install pinact
 (`brew install pinact`), then `pre-commit install`.
 
-### Adding it to a repo
+### Enabling the check
 
-1. Copy `.pinact.yml` and the Dependabot config (see Prerequisites).
+1. Copy `.pinact.yml` and the Dependabot config (see "Required files" above).
 2. Open the repo on GitHub and go to **Actions -> New workflow**. Under
    **By Geolonia**, pick **Action Pinning Check** and **Configure**.
 3. Run `pinact run` once locally (or let the pre-commit hook do it) to

--- a/pinact/.pinact.yml
+++ b/pinact/.pinact.yml
@@ -1,0 +1,26 @@
+# Canonical pinact config for the Geolonia org.
+#
+# Drop this file at the root of your repository as `.pinact.yml`. pinact
+# reads it both locally (pre-commit, manual `pinact run`) and in CI (the
+# Action Pinning Check), so local and CI behave identically.
+#
+# What it does:
+#
+#   min_age.value: 7    Do not pin (or update to) an action release that
+#                       is younger than 7 days. A freshly published tag or
+#                       release is the window when a hijacked-tag supply
+#                       chain attack is most likely to still be live, so
+#                       we wait it out. This is the GitHub Actions analog
+#                       of pnpm's `minimumReleaseAge`.
+#
+#   min_age.always: true  Verify the 7-day age of CURRENT pins on every
+#                       run, not only when `--verify-min-age` is passed.
+#                       Keeps the rule on by default for local runs.
+#
+# Bump an action by letting Dependabot (github-actions, weekly, with a
+# matching 7-day cooldown) open the PR, or run `pinact run --update`
+# locally. Do not hand-edit the SHA or the version comment; pinact keeps
+# the two in sync.
+min_age:
+  value: 7
+  always: true

--- a/pinact/.pre-commit-config.example.yaml
+++ b/pinact/.pre-commit-config.example.yaml
@@ -1,0 +1,35 @@
+# Example pre-commit-framework config for the Geolonia org.
+#
+# Drop this file at the root of your repository as `.pre-commit-config.yaml`
+# (merge the `repos:` list if you already have one), then run once per
+# laptop:
+#
+#   brew install pre-commit pinact   # pinact tap: suzuki-shunsuke/pinact
+#   pre-commit install
+#
+# After that, `git commit` runs pinact on the staged workflow files and
+# pins any unpinned action (and refuses the commit if a pin is younger
+# than the 7-day minimum release age in .pinact.yml). Same engine and
+# same rules as the per-PR Action Pinning Check, so feedback is
+# consistent between local and CI.
+#
+# pinact must be on PATH. Install it with Homebrew (above), aqua, or
+# `go install github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.0.0`.
+# Pin the same v4 line that the CI gate (pinact-action v3) bundles, so
+# local and CI use the same engine.
+#
+# Bypass for the rare commit that must go in despite the hook
+# (the CI gate still catches it on the PR):
+#
+#   git commit --no-verify
+
+repos:
+  - repo: local
+    hooks:
+      - id: pinact
+        name: pinact (pin GitHub Actions)
+        entry: pinact run
+        language: system
+        # Only run when a workflow or action definition changes.
+        files: ^(\.github/workflows/.*\.ya?ml|action\.ya?ml)$
+        pass_filenames: false

--- a/pinact/.pre-commit-config.example.yaml
+++ b/pinact/.pre-commit-config.example.yaml
@@ -30,6 +30,8 @@ repos:
         name: pinact (pin GitHub Actions)
         entry: pinact run
         language: system
-        # Only run when a workflow or action definition changes.
-        files: ^(\.github/workflows/.*\.ya?ml|action\.ya?ml)$
+        # Only run when a workflow or action definition changes. Matches
+        # workflow files plus action.yml/action.yaml at any depth (composite
+        # actions live in subdirectories).
+        files: (^\.github/workflows/.*\.ya?ml$|(^|/)action\.ya?ml$)
         pass_filenames: false

--- a/workflow-templates/pinact-check.properties.json
+++ b/workflow-templates/pinact-check.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Action Pinning Check (per PR)",
+  "description": "Verify every GitHub Action is pinned to a commit SHA with a matching version comment and meets the org 7-day minimum release age, using pinact. Requires a .pinact.yml at the repo root.",
+  "iconName": "lock",
+  "categories": ["Automation"],
+  "filePatterns": [".github/workflows/.*"]
+}

--- a/workflow-templates/pinact-check.yml
+++ b/workflow-templates/pinact-check.yml
@@ -2,7 +2,7 @@ name: Action Pinning Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [$default-branch]
 
 permissions:
   contents: read

--- a/workflow-templates/pinact-check.yml
+++ b/workflow-templates/pinact-check.yml
@@ -1,0 +1,17 @@
+name: Action Pinning Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@v1
+    # Verifies every GitHub Action in this repo is SHA-pinned, carries a
+    # matching version comment, and meets the 7-day minimum release age.
+    # Requires a .pinact.yml at the repo root (copy the org canonical one
+    # from geolonia/.github: pinact/.pinact.yml) and pairs with a
+    # Dependabot github-actions config to keep pins current.


### PR DESCRIPTION
Builds the enforcement primitive and shared config for the org GitHub Actions pinning standard (geolonia-operations#143 + #148).

## What this adds

- **`.github/workflows/reusable-pinact-check.yml`** — per-PR reusable gate that runs [pinact](https://github.com/suzuki-shunsuke/pinact) in validation-only mode (`fix: false` + `--verify-comment` + `--verify-min-age`). It never edits files or pushes; it only fails the check when an action is unpinned, has a mismatched version comment, or is younger than the configured minimum release age. Its own actions are SHA-pinned (`actions/checkout` v6.0.2, `suzuki-shunsuke/pinact-action` v3.0.0).
- **`workflow-templates/pinact-check.yml` + `.properties.json`** — org Actions-picker template so any repo opts in with a few lines.
- **`pinact/.pinact.yml`** — canonical `min_age: { value: 7, always: true }` config repos copy (the Actions analog of pnpm `minimumReleaseAge`).
- **`pinact/.pre-commit-config.example.yaml`** — local auto-pin hook so devs pin before pushing.
- **`docs/workflows.md`** — usage, prerequisites (`.pinact.yml` + Dependabot github-actions w/ cooldown 7 + groups), local pre-commit, adoption steps.

## Notes

- `pinact-action` v3.0.0 bundles pinact CLI **v4.0.0**, so CI and local runs use the same engine.
- This PR only builds the primitive + shared config. Rolling the standard out across workspace repos (starting with a geolonia-infra-cdk pilot) and the `@v1` tag move happen in follow-ups.
- After merge, push the immutable version tag so the auto-release workflow floats `v1` to include this reusable workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated action pinning validation for pull requests that enforces SHA pinning, matching version comments, and a 7-day minimum release age.

* **Documentation**
  * Added a setup guide, usage reference, and step-by-step instructions for enabling the pinning check in repos.

* **Chores**
  * Added reusable workflow, workflow template, canonical pinning configuration, and an example pre-commit config to support the check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->