### PR TITLE
fix(pinact): canonical .pinact.yml needs version 3 + geolonia exemption

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -168,7 +168,10 @@ Two files at the repo root, both copyable from `geolonia/.github`:
    release age (org default: 7 days, `min_age.value: 7`, `always: true`).
    This is the GitHub Actions analog of pnpm's `minimumReleaseAge`: a new
    tag is not adopted until it has survived a week, the window when a
-   hijacked-tag attack is most likely to still be live.
+   hijacked-tag attack is most likely to still be live. The canonical
+   file exempts `geolonia/*` from the cooldown (we author our own
+   releases; the window guards against third-party tag hijacks) and is
+   still SHA-pinned.
 2. **`.github/dependabot.yml`** with a `github-actions` ecosystem entry,
    `cooldown: { default-days: 7 }` (matches the pinact min age), and a
    `groups` block batching minor/patch bumps into one PR while majors

--- a/pinact/.pinact.yml
+++ b/pinact/.pinact.yml
@@ -2,7 +2,8 @@
 #
 # Drop this file at the root of your repository as `.pinact.yml`. pinact
 # reads it both locally (pre-commit, manual `pinact run`) and in CI (the
-# Action Pinning Check), so local and CI behave identically.
+# Action Pinning Check), so local and CI behave identically. Requires
+# pinact v4+ (the `version` field below).
 #
 # What it does:
 #
@@ -17,10 +18,27 @@
 #                       run, not only when `--verify-min-age` is passed.
 #                       Keeps the rule on by default for local runs.
 #
+#   rules (geolonia/*)  Exempt our own org from the cooldown. The 7-day
+#                       window guards against a hijacked THIRD-PARTY
+#                       release; we author and control geolonia/* releases
+#                       ourselves, and a brand-new geolonia/.github
+#                       reusable would otherwise be un-adoptable for a
+#                       week (no older release contains it). Still
+#                       SHA-pinned; Dependabot maintains them.
+#
 # Bump an action by letting Dependabot (github-actions, weekly, with a
 # matching 7-day cooldown) open the PR, or run `pinact run --update`
 # locally. Do not hand-edit the SHA or the version comment; pinact keeps
 # the two in sync.
+version: 3
+# Two spaces before the version comment, matching the org's existing pin
+# style (pinact's default is a single space).
+separator: "  # "
 min_age:
   value: 7
   always: true
+rules:
+  - min_age: 0
+    conditions:
+      - expr: |
+          ActionName matches "geolonia/.*"


### PR DESCRIPTION
Follow-up to #48. The canonical `pinact/.pinact.yml` shipped in v1.15.0 is missing the required `version: 3` schema field, so **pinact v4 errors on it** (`schema version is required`). This adds it, plus two refinements proven in the geolonia-infra-cdk pilot (geolonia-infra-cdk#133):

- **`version: 3`** — required by pinact v4; without it `pinact run` aborts.
- **`separator: "  # "`** — pins match the org two-space comment style (pinact default is one space).
- **`rules` exempting `geolonia/*` from the cooldown** — the 7-day cooldown guards against a hijacked *third-party* release. We author and control `geolonia/*` releases ourselves, and a brand-new `geolonia/.github` reusable would otherwise be un-adoptable for a week (no older release contains it). Still SHA-pinned; Dependabot maintains them.

Docs note the exemption.

Part of geolonia-operations#144 / epic geolonia-operations#142.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced workflow documentation with clearer explanations of action pinning checks and cooldown behavior.

* **Chores**
  * Updated configuration requirements (now requiring v4+) and added explicit settings for improved organization-specific management controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->