### PR TITLE
docs(pinact): standard Dependabot cooldown is 8 days (one over min_age 7)

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -173,10 +173,14 @@ Two files at the repo root, both copyable from `geolonia/.github`:
    releases; the window guards against third-party tag hijacks) and is
    still SHA-pinned.
 2. **`.github/dependabot.yml`** with a `github-actions` ecosystem entry,
-   `cooldown: { default-days: 7 }` (matches the pinact min age), and a
-   `groups` block batching minor/patch bumps into one PR while majors
-   arrive individually. Dependabot bumps the SHA and the version comment
-   together, so pins never go stale.
+   `cooldown: { default-days: 8 }`, and a `groups` block batching
+   minor/patch bumps into one PR while majors arrive individually.
+   Dependabot bumps the SHA and the version comment together, so pins
+   never go stale. The cooldown is one day longer than the pinact
+   `min_age` of 7: Dependabot counts whole calendar days while pinact
+   enforces an exact 168h floor, so an 8-day cooldown guarantees a
+   Dependabot PR always clears the Action Pinning Check on arrival
+   instead of failing it for a few hours at the day boundary.
 
 ### Check inputs
 

--- a/pinact/.pinact.yml
+++ b/pinact/.pinact.yml
@@ -26,8 +26,9 @@
 #                       week (no older release contains it). Still
 #                       SHA-pinned; Dependabot maintains them.
 #
-# Bump an action by letting Dependabot (github-actions, weekly, with a
-# matching 7-day cooldown) open the PR, or run `pinact run --update`
+# Bump an action by letting Dependabot (github-actions, weekly, with an
+# 8-day cooldown: one day over this min_age, so its PRs always clear the
+# pinact gate) open the PR, or run `pinact run --update`
 # locally. Do not hand-edit the SHA or the version comment; pinact keeps
 # the two in sync.
 version: 3


### PR DESCRIPTION
Documents the cooldown fix from the infra-cdk pilot (geolonia-infra-cdk#135).

Dependabot counts `cooldown` in calendar days while pinact `--verify-min-age` enforces an exact 168h floor. At the day boundary Dependabot could open a SHA-pinned PR a few hours before pinact accepts the pin, producing a transient red Action Pinning Check (seen on geolonia-infra-cdk#134). Setting the standard `cooldown` to **8** (one day over the 7-day `min_age`) guarantees Dependabot PRs clear the gate on arrival.

`pinact` remains the hard 7-day floor; Dependabot just waits a day longer so it always clears it.

Part of geolonia-operations#144 / epic geolonia-operations#142.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Dependabot/action pinning guidance to use an 8-day cooldown (previously 7 days) and adjusted explanatory text to reflect the one-day-longer cooldown relative to pinning timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->