### PR TITLE
docs: team best-practice guide for pinning GitHub Actions (#146)

### DIFF
--- a/docs/github-actions-pinning.md
+++ b/docs/github-actions-pinning.md
@@ -126,7 +126,8 @@ artifact. Setting `persist-credentials: false` is optional hygiene on v6+, not a
 requirement. It still matters on v5 and earlier.
 
 **How do I adopt the standard in a new or existing repo?**
-Copy `.pinact.yml` and `.github/dependabot.yml` from this repo, add the Action
+Copy this repo's canonical `pinact/.pinact.yml` to your repo root as
+`.pinact.yml`, copy `.github/dependabot.yml`, add the Action
 Pinning Check workflow (see the
 [Reusable workflows](workflows.md#action-pinning-check-reusable-pinact-checkyml)
 page), then run `pinact run` once to pin the existing workflows. New repos

--- a/docs/github-actions-pinning.md
+++ b/docs/github-actions-pinning.md
@@ -15,15 +15,15 @@ section of the Reusable workflows page.
 ## Why pin to a commit SHA
 
 A tag like `@v4` is **mutable**: whoever controls the action's repository can
-move it to point at different code at any time. If a popular action is
-compromised (not hypothetical, it happened to `tj-actions/changed-files` in
-2026), every workflow that uses the moved tag silently runs the attacker's code
-on its next run, with access to that workflow's `GITHUB_TOKEN` and secrets.
+move it to point at different code at any time, even after you have reviewed it.
+Pinning to a tag trusts that it will never be changed or hijacked.
 
 A 40-character commit SHA is **immutable**: it always resolves to the exact
-commit you reviewed, so a hijacked tag cannot change what runs in CI. The
-trailing `# v6.0.2` comment keeps the line readable. The classic downside of SHA
-pinning is staleness, which we remove with Dependabot.
+commit you reviewed. So a moved or hijacked tag cannot silently swap in
+different code on your next workflow run, where it would have access to your
+`GITHUB_TOKEN` and secrets. That is what pinning to a SHA prevents. The trailing
+`# v6.0.2` comment keeps the line readable. The classic downside of SHA pinning
+is staleness, which we remove with Dependabot.
 
 ## How the pieces fit together
 
@@ -39,7 +39,7 @@ The 7-day wait is the same idea as pnpm's `minimumReleaseAge`, which we also use
 for npm dependencies: do not adopt a release until it has survived a week, the
 window in which a malicious release is most likely to be caught and pulled. The
 Dependabot `cooldown` is set to **8** days (one more than pinact's 7) because
-Dependabot counts whole calendar days while pinact enforces an exact 168 hour
+Dependabot counts whole calendar days while pinact enforces an exact 168-hour
 floor, so the extra day guarantees Dependabot PRs pass the check on arrival.
 
 ## Adopting it in a repo

--- a/docs/github-actions-pinning.md
+++ b/docs/github-actions-pinning.md
@@ -7,8 +7,8 @@ SHA with a readable version comment, and let automation keep it current:
 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 ```
 
-This page is the "why and how" for developers. For the reusable CI check and
-the exact files to copy, see the
+This page explains why and how to adopt it. The reusable CI check itself is
+documented in the
 [Action Pinning Check](workflows.md#action-pinning-check-reusable-pinact-checkyml)
 section of the Reusable workflows page.
 
@@ -16,128 +16,68 @@ section of the Reusable workflows page.
 
 A tag like `@v4` is **mutable**: whoever controls the action's repository can
 move it to point at different code at any time. If a popular action is
-compromised (this is not hypothetical, it happened to `tj-actions/changed-files`
-in 2026), every workflow that uses the moved tag silently runs the attacker's
-code on its next run, with access to that workflow's `GITHUB_TOKEN` and secrets.
+compromised (not hypothetical, it happened to `tj-actions/changed-files` in
+2026), every workflow that uses the moved tag silently runs the attacker's code
+on its next run, with access to that workflow's `GITHUB_TOKEN` and secrets.
 
 A 40-character commit SHA is **immutable**: it always resolves to the exact
-commit you reviewed, so a hijacked tag cannot change what runs in your CI. The
-trailing `# v6.0.2` comment keeps the line readable so you can still tell at a
-glance which version is pinned.
-
-The classic downside of SHA pinning is staleness (pinned SHAs do not pick up
-fixes on their own). We remove that downside with Dependabot, which bumps the
-SHA and rewrites the version comment for us.
+commit you reviewed, so a hijacked tag cannot change what runs in CI. The
+trailing `# v6.0.2` comment keeps the line readable. The classic downside of SHA
+pinning is staleness, which we remove with Dependabot.
 
 ## How the pieces fit together
 
-Three tools enforce one simple rule: **nothing younger than 7 days**.
+Three tools enforce one rule: **nothing younger than 7 days**.
 
 | Tool | Role |
 | --- | --- |
 | **pinact** | Pins actions (writes the SHA + version comment) and verifies them. The Action Pinning Check CI gate runs pinact in validation-only mode and fails a PR if any action is unpinned, has a mismatched comment, or is younger than the minimum release age. It never edits files in CI. |
-| **Dependabot** | Maintains pins. Weekly it opens PRs that bump the SHA and the comment together. A `cooldown` defers brand-new releases. |
-| **`.pinact.yml`** | Sets the `min_age` (7 days) used by pinact, and exempts our own `geolonia/*` actions from the wait. |
+| **Dependabot** | Maintains pins. Weekly it opens PRs that bump the SHA and the comment together, deferred by a `cooldown`. |
+| **`.pinact.yml`** | Sets the `min_age` (7 days) and exempts our own `geolonia/*` actions from the wait. |
 
 The 7-day wait is the same idea as pnpm's `minimumReleaseAge`, which we also use
 for npm dependencies: do not adopt a release until it has survived a week, the
-window in which a hijacked or malicious release is most likely to be caught and
-pulled. One consistent rule across both npm packages and GitHub Actions.
+window in which a malicious release is most likely to be caught and pulled. The
+Dependabot `cooldown` is set to **8** days (one more than pinact's 7) because
+Dependabot counts whole calendar days while pinact enforces an exact 168 hour
+floor, so the extra day guarantees Dependabot PRs pass the check on arrival.
 
-Two numbers that look almost the same and why they differ:
+## Adopting it in a repo
 
-- pinact `min_age` is **7** days (an exact 168 hour floor).
-- Dependabot `cooldown` is **8** days. Dependabot counts whole calendar days,
-  so setting it one day higher guarantees its PRs are always past pinact's
-  exact 168 hour floor when they open, and therefore pass the CI check on
-  arrival instead of failing it for a few hours at the day boundary.
+New repos created from the Backstage scaffolder get everything below out of the
+box. For an existing repo:
 
-## Adding or changing an action
+1. Copy the canonical config from this repository's
+   [`pinact/`](https://github.com/geolonia/.github/tree/main/pinact) directory:
+   - `pinact/.pinact.yml` to your repo root as `.pinact.yml`
+   - `pinact/dependabot.yml` to `.github/dependabot.yml` (merge the
+     `github-actions` entry if you already have one)
+   - optional: `pinact/.pre-commit-config.example.yaml` to your repo root as
+     `.pre-commit-config.yaml` (auto-pins on every commit)
+2. Add the **Action Pinning Check** workflow, either way:
+   - **From the GitHub UI:** in your repo, open **Actions -> New workflow**,
+     and under **By Geolonia** choose **Action Pinning Check**, then
+     **Configure** and commit the suggested file.
+   - **By copying the file:** see the
+     [Action Pinning Check](workflows.md#action-pinning-check-reusable-pinact-checkyml)
+     reference.
+3. Run `pinact run` once (or let the pre-commit hook do it) to pin the existing
+   workflows, then commit.
 
-**Do not hand-write or hand-edit the SHA.** Write the normal human-readable tag
-and let the tooling pin it:
+## Day to day
 
-```yaml
-# write this:
-uses: actions/setup-node@v6
-# pinact turns it into:
-uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-```
-
-Easiest path, install the pre-commit hook once per laptop so commits are pinned
-automatically:
-
-```bash
-brew install pinact pre-commit          # pinact tap: suzuki-shunsuke/pinact
-cp /path/to/geolonia/.github/pinact/.pre-commit-config.example.yaml .pre-commit-config.yaml
-pre-commit install
-```
-
-After that, `git commit` runs pinact on changed workflow files and pins anything
-new. You can also run it manually any time with `pinact run`.
-
-To intentionally move an action to a newer version, run `pinact run --update`
-(it still honors the 7-day minimum age). In day-to-day work you rarely need to:
-Dependabot does the bumping for you.
-
-## Handling a Dependabot pull request
-
-Dependabot opens these weekly. Each one has already applied the bump (SHA +
-version comment) and links the upstream changelog.
-
-- **Minor and patch** bumps arrive grouped into a single PR. Skim the changelog,
-  confirm CI is green (including the Action Pinning Check), and merge.
-- **Major** bumps arrive as individual PRs so you can review the breaking
-  changes on their own.
-
-You never edit the SHA yourself; just review and merge.
-
-## When the Action Pinning Check fails
-
-The check is failing for one of these reasons. The fix is almost always "let
-pinact do it," never "hand-edit the SHA."
-
-| Message | Cause | Fix |
-| --- | --- | --- |
-| GitHub Actions aren't pinned | An action still uses a tag or branch | Run `pinact run` (or let the pre-commit hook run), commit the result |
-| Version comment does not match the SHA | The `# vX.Y.Z` comment drifted from the pinned commit | Run `pinact run` to rewrite the comment |
-| Action version is younger than the min-age cutoff | The pinned release is less than 7 days old | Wait until it ages past 7 days, or pin the previous (older) release. This is the cooldown protecting you from brand-new releases |
-
-## FAQ
-
-**Does SHA pinning mean we miss security updates?**
-No. Dependabot bumps pins weekly (the SHA and the comment together), so fixes
-still flow in through reviewed PRs.
-
-**Why keep the version comment if the SHA is what matters?**
-Readability. pinact keeps the comment in sync with the SHA, so it is safe to
-trust at a glance and never drifts.
-
-**Do I pin first-party actions like `actions/checkout` too?**
-Yes, all actions are pinned, first-party included. Our own `geolonia/*` reusable
-workflows are pinned as well; Dependabot maintains them, and they are exempt
-only from the 7-day cooldown (we author and control those releases, so the
-hijacked-third-party-release risk the cooldown guards against does not apply).
-
-**Do I need `persist-credentials: false` on `actions/checkout`?**
-Not on v6 or newer. As of checkout v6 the token is stored outside the repo
-working tree, which closes the path where it could leak through an uploaded
-artifact. Setting `persist-credentials: false` is optional hygiene on v6+, not a
-requirement. It still matters on v5 and earlier.
-
-**How do I adopt the standard in a new or existing repo?**
-Copy this repo's canonical `pinact/.pinact.yml` to your repo root as
-`.pinact.yml`, copy `.github/dependabot.yml`, add the Action
-Pinning Check workflow (see the
-[Reusable workflows](workflows.md#action-pinning-check-reusable-pinact-checkyml)
-page), then run `pinact run` once to pin the existing workflows. New repos
-created from the Backstage scaffolder get all of this out of the box.
+- **Never hand-edit a SHA.** Write the normal tag (`actions/setup-node@v6`) and
+  let pinact pin it, via the pre-commit hook or `pinact run`. If the Action
+  Pinning Check ever fails, the fix is to run `pinact run`, never to edit the
+  SHA by hand.
+- **Dependabot does the bumping.** It opens weekly PRs that update the SHA and
+  the version comment together: minor and patch grouped into one PR, majors
+  individually. Skim the linked changelog, confirm CI is green, and merge.
 
 ## See also
 
 - [Action Pinning Check reusable workflow](workflows.md#action-pinning-check-reusable-pinact-checkyml)
-- Canonical config to copy: `pinact/.pinact.yml` and
-  `pinact/.pre-commit-config.example.yaml` in this repository.
-- [pinact](https://github.com/suzuki-shunsuke/pinact) and
-  [Dependabot cooldown](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown)
-  upstream docs.
+- Canonical config to copy:
+  [`pinact/`](https://github.com/geolonia/.github/tree/main/pinact)
+  (`.pinact.yml`, `dependabot.yml`, `.pre-commit-config.example.yaml`).
+- [pinact](https://github.com/suzuki-shunsuke/pinact) upstream documentation.

--- a/docs/github-actions-pinning.md
+++ b/docs/github-actions-pinning.md
@@ -1,0 +1,142 @@
+# Pinning GitHub Actions
+
+Our org standard is to pin every GitHub Action to a full 40-character commit
+SHA with a readable version comment, and let automation keep it current:
+
+```yaml
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+```
+
+This page is the "why and how" for developers. For the reusable CI check and
+the exact files to copy, see the
+[Action Pinning Check](workflows.md#action-pinning-check-reusable-pinact-checkyml)
+section of the Reusable workflows page.
+
+## Why pin to a commit SHA
+
+A tag like `@v4` is **mutable**: whoever controls the action's repository can
+move it to point at different code at any time. If a popular action is
+compromised (this is not hypothetical, it happened to `tj-actions/changed-files`
+in 2026), every workflow that uses the moved tag silently runs the attacker's
+code on its next run, with access to that workflow's `GITHUB_TOKEN` and secrets.
+
+A 40-character commit SHA is **immutable**: it always resolves to the exact
+commit you reviewed, so a hijacked tag cannot change what runs in your CI. The
+trailing `# v6.0.2` comment keeps the line readable so you can still tell at a
+glance which version is pinned.
+
+The classic downside of SHA pinning is staleness (pinned SHAs do not pick up
+fixes on their own). We remove that downside with Dependabot, which bumps the
+SHA and rewrites the version comment for us.
+
+## How the pieces fit together
+
+Three tools enforce one simple rule: **nothing younger than 7 days**.
+
+| Tool | Role |
+| --- | --- |
+| **pinact** | Pins actions (writes the SHA + version comment) and verifies them. The Action Pinning Check CI gate runs pinact in validation-only mode and fails a PR if any action is unpinned, has a mismatched comment, or is younger than the minimum release age. It never edits files in CI. |
+| **Dependabot** | Maintains pins. Weekly it opens PRs that bump the SHA and the comment together. A `cooldown` defers brand-new releases. |
+| **`.pinact.yml`** | Sets the `min_age` (7 days) used by pinact, and exempts our own `geolonia/*` actions from the wait. |
+
+The 7-day wait is the same idea as pnpm's `minimumReleaseAge`, which we also use
+for npm dependencies: do not adopt a release until it has survived a week, the
+window in which a hijacked or malicious release is most likely to be caught and
+pulled. One consistent rule across both npm packages and GitHub Actions.
+
+Two numbers that look almost the same and why they differ:
+
+- pinact `min_age` is **7** days (an exact 168 hour floor).
+- Dependabot `cooldown` is **8** days. Dependabot counts whole calendar days,
+  so setting it one day higher guarantees its PRs are always past pinact's
+  exact 168 hour floor when they open, and therefore pass the CI check on
+  arrival instead of failing it for a few hours at the day boundary.
+
+## Adding or changing an action
+
+**Do not hand-write or hand-edit the SHA.** Write the normal human-readable tag
+and let the tooling pin it:
+
+```yaml
+# write this:
+uses: actions/setup-node@v6
+# pinact turns it into:
+uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+```
+
+Easiest path, install the pre-commit hook once per laptop so commits are pinned
+automatically:
+
+```bash
+brew install pinact pre-commit          # pinact tap: suzuki-shunsuke/pinact
+cp /path/to/geolonia/.github/pinact/.pre-commit-config.example.yaml .pre-commit-config.yaml
+pre-commit install
+```
+
+After that, `git commit` runs pinact on changed workflow files and pins anything
+new. You can also run it manually any time with `pinact run`.
+
+To intentionally move an action to a newer version, run `pinact run --update`
+(it still honors the 7-day minimum age). In day-to-day work you rarely need to:
+Dependabot does the bumping for you.
+
+## Handling a Dependabot pull request
+
+Dependabot opens these weekly. Each one has already applied the bump (SHA +
+version comment) and links the upstream changelog.
+
+- **Minor and patch** bumps arrive grouped into a single PR. Skim the changelog,
+  confirm CI is green (including the Action Pinning Check), and merge.
+- **Major** bumps arrive as individual PRs so you can review the breaking
+  changes on their own.
+
+You never edit the SHA yourself; just review and merge.
+
+## When the Action Pinning Check fails
+
+The check is failing for one of these reasons. The fix is almost always "let
+pinact do it," never "hand-edit the SHA."
+
+| Message | Cause | Fix |
+| --- | --- | --- |
+| GitHub Actions aren't pinned | An action still uses a tag or branch | Run `pinact run` (or let the pre-commit hook run), commit the result |
+| Version comment does not match the SHA | The `# vX.Y.Z` comment drifted from the pinned commit | Run `pinact run` to rewrite the comment |
+| Action version is younger than the min-age cutoff | The pinned release is less than 7 days old | Wait until it ages past 7 days, or pin the previous (older) release. This is the cooldown protecting you from brand-new releases |
+
+## FAQ
+
+**Does SHA pinning mean we miss security updates?**
+No. Dependabot bumps pins weekly (the SHA and the comment together), so fixes
+still flow in through reviewed PRs.
+
+**Why keep the version comment if the SHA is what matters?**
+Readability. pinact keeps the comment in sync with the SHA, so it is safe to
+trust at a glance and never drifts.
+
+**Do I pin first-party actions like `actions/checkout` too?**
+Yes, all actions are pinned, first-party included. Our own `geolonia/*` reusable
+workflows are pinned as well; Dependabot maintains them, and they are exempt
+only from the 7-day cooldown (we author and control those releases, so the
+hijacked-third-party-release risk the cooldown guards against does not apply).
+
+**Do I need `persist-credentials: false` on `actions/checkout`?**
+Not on v6 or newer. As of checkout v6 the token is stored outside the repo
+working tree, which closes the path where it could leak through an uploaded
+artifact. Setting `persist-credentials: false` is optional hygiene on v6+, not a
+requirement. It still matters on v5 and earlier.
+
+**How do I adopt the standard in a new or existing repo?**
+Copy `.pinact.yml` and `.github/dependabot.yml` from this repo, add the Action
+Pinning Check workflow (see the
+[Reusable workflows](workflows.md#action-pinning-check-reusable-pinact-checkyml)
+page), then run `pinact run` once to pin the existing workflows. New repos
+created from the Backstage scaffolder get all of this out of the box.
+
+## See also
+
+- [Action Pinning Check reusable workflow](workflows.md#action-pinning-check-reusable-pinact-checkyml)
+- Canonical config to copy: `pinact/.pinact.yml` and
+  `pinact/.pre-commit-config.example.yaml` in this repository.
+- [pinact](https://github.com/suzuki-shunsuke/pinact) and
+  [Dependabot cooldown](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown)
+  upstream docs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,4 +24,5 @@ Geolonia repositories.
 
 - [Community health](community-health.md)
 - [Reusable workflows](workflows.md)
+- [Pinning GitHub Actions](github-actions-pinning.md)
 - [Organization profile](profile.md)

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -172,7 +172,8 @@ Two files at the repo root, both copyable from `geolonia/.github`:
    file exempts `geolonia/*` from the cooldown (we author our own
    releases; the window guards against third-party tag hijacks) and is
    still SHA-pinned.
-2. **`.github/dependabot.yml`** with a `github-actions` ecosystem entry,
+2. **`.github/dependabot.yml`** (copy `pinact/dependabot.yml`) with a
+   `github-actions` ecosystem entry,
    `cooldown: { default-days: 8 }`, and a `groups` block batching
    minor/patch bumps into one PR while majors arrive individually.
    Dependabot bumps the SHA and the version comment together, so pins

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ nav:
   - Overview: index.md
   - Community Health: community-health.md
   - Workflows: workflows.md
+  - GitHub Actions Pinning: github-actions-pinning.md
   - Organization Profile: profile.md
 docs_dir: docs
 theme:

--- a/pinact/dependabot.yml
+++ b/pinact/dependabot.yml
@@ -1,0 +1,30 @@
+# Canonical Dependabot config for the Geolonia GitHub Actions pinning standard.
+#
+# Copy this file to `.github/dependabot.yml` in your repository. If your repo
+# already has a `.github/dependabot.yml`, merge the `github-actions` entry below
+# into its existing `updates:` list instead of overwriting the file.
+#
+# Dependabot keeps SHA pins current: it bumps both the commit SHA and the
+# trailing version comment, so SHA-pinning never goes stale. The 8-day cooldown
+# is one day longer than the `.pinact.yml` min_age of 7 (Dependabot counts whole
+# calendar days while pinact enforces an exact 168h floor), so a Dependabot PR
+# always clears the Action Pinning Check on arrival.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 8
+    groups:
+      # Batch minor and patch bumps into a single weekly PR. Majors are
+      # excluded here, so breaking upgrades arrive as individual PRs that get
+      # isolated review. Security updates also stay individual (groups defaults
+      # to applies-to: version-updates).
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Closes the documentation sub-issue of the Actions pinning standard (geolonia-operations#146, epic geolonia-operations#142).

Adds **`docs/github-actions-pinning.md`** — a developer-facing guide covering:

- **Why** we pin to a commit SHA (mutable tags vs immutable SHA, the supply-chain risk in plain terms, with the `tj-actions/changed-files` example).
- **How the pieces fit** — pinact (pins + verifies) + Dependabot (maintains + cooldown) + `.pinact.yml` (min-age), the one "nothing younger than 7 days" rule shared with pnpm, and why Dependabot `cooldown` is 8 while pinact `min_age` is 7.
- **Adding/changing an action** — never hand-edit SHAs; let the pre-commit hook / `pinact run` do it.
- **Handling a Dependabot PR** and **a failing Action Pinning Check** (table of causes + fixes).
- **FAQ** — missed updates, version comments, first-party pinning, `persist-credentials` on checkout v6+, adopting in a new repo.

It cross-links the [Action Pinning Check reusable-workflow reference](https://github.com/geolonia/.github/blob/docs/actions-pinning-guide/docs/workflows.md#action-pinning-check-reusable-pinact-checkyml) rather than duplicating it. Also added to the mkdocs nav and the index Related pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "GitHub Actions Pinning" guide covering rationale, enforcement, adoption steps, operational rules, remediation, and links to related resources; added the guide to site navigation and related pages.
* **Chores**
  * Added a canonical Dependabot configuration for action pinning and updated workflow docs to reference copying it into repositories and required workflow checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->