### PR TITLE
feat: route-issue reusable workflow + template (public dispatch leg)

### DIFF
--- a/.github/workflows/reusable-route-issue.yml
+++ b/.github/workflows/reusable-route-issue.yml
@@ -45,13 +45,17 @@ on:
         type: string
         required: false
         default: "route-issue"
-      remove_on_field_removed:
+      exclusive_routing:
         description: >-
-          When this repo's Department field is cleared, also remove the issue
-          from its team board(s). Default: keep the issue on the board.
+          Keep each issue on only the board for its current Department: when the
+          department changes, the issue is removed from the other department
+          boards; when it is cleared, it is removed from all of them. Only
+          department boards are ever touched (never a master/all-work board or
+          an unrelated project). Default: true. Set false for additive routing
+          (add only, never remove).
         type: boolean
         required: false
-        default: false
+        default: true
     secrets:
       OPS_DISPATCH_CLIENT_ID:
         description: "Dispatch GitHub App client id (dispatches into geolonia-operations)."
@@ -88,7 +92,7 @@ jobs:
           ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ACTION: ${{ github.event.action }}
-          REMOVE_ON_FIELD_REMOVED: ${{ inputs.remove_on_field_removed }}
+          EXCLUSIVE_ROUTING: ${{ inputs.exclusive_routing }}
         shell: bash
         run: |
           set -euo pipefail
@@ -105,7 +109,7 @@ jobs:
             --arg node_id "$ISSUE_NODE_ID" \
             --arg url "$ISSUE_URL" \
             --arg action "$ACTION" \
-            --argjson remove "$REMOVE_ON_FIELD_REMOVED" \
+            --argjson exclusive "$EXCLUSIVE_ROUTING" \
             '{
               event_type: $event_type,
               client_payload: {
@@ -114,7 +118,7 @@ jobs:
                 issue_node_id: $node_id,
                 issue_url: $url,
                 action: $action,
-                remove_on_field_removed: $remove
+                exclusive_routing: $exclusive
               }
             }')
 

--- a/.github/workflows/reusable-route-issue.yml
+++ b/.github/workflows/reusable-route-issue.yml
@@ -50,9 +50,9 @@ on:
           Keep each issue on only the board for its current Department: when the
           department changes, the issue is removed from the other department
           boards; when it is cleared, it is removed from all of them. Only
-          department boards are ever touched (never a master/all-work board or
-          an unrelated project). Default: true. Set false for additive routing
-          (add only, never remove).
+          department boards are ever touched; any other project an issue sits on
+          is left alone. Default: true. Set false for additive routing (add
+          only, never remove).
         type: boolean
         required: false
         default: true

--- a/.github/workflows/reusable-route-issue.yml
+++ b/.github/workflows/reusable-route-issue.yml
@@ -1,0 +1,113 @@
+name: "[REUSABLE] Route issue to team board"
+
+# Forwarder for org-wide issue auto-routing.
+#
+# When an issue's org-level issue field changes in a participating repo, this
+# workflow mints a low-privilege dispatch token and sends a repository_dispatch
+# event to the central, PRIVATE geolonia-operations repo. That repo holds all
+# the routing logic, project IDs, and the privileged Org-Projects token and
+# decides which team board (if any) the issue belongs on.
+#
+# This public side is deliberately dumb: it never reads the field value, never
+# sees a project ID, and never holds the Org-Projects credential. It only knows
+# "an issue field changed here, node id X — operations, take it from here." That
+# keeps every secret and every routing decision private, mirroring the
+# reusable-sync-team-access.yml dispatch-to-central pattern (individual repos
+# never see the org token).
+#
+# Consumer wrapper (in any repo, on the DEFAULT branch so the trigger fires):
+#
+#   name: Route issue to team board
+#   on:
+#     issues:
+#       types: [field_added, field_removed]
+#   permissions:
+#     contents: read
+#   jobs:
+#     route:
+#       uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
+#       secrets: inherit
+#
+# Requires the org-level dispatch secrets (already used by sync-team-access) to
+# be visible to the calling repo:
+#   OPS_DISPATCH_CLIENT_ID, OPS_DISPATCH_APP_PRIVATE_KEY
+
+on:
+  workflow_call:
+    inputs:
+      operations_repo:
+        description: "Central repo (name only) that processes routing requests."
+        type: string
+        required: false
+        default: "geolonia-operations"
+      event_type:
+        description: "repository_dispatch event_type the central repo listens for."
+        type: string
+        required: false
+        default: "route-issue"
+    secrets:
+      OPS_DISPATCH_CLIENT_ID:
+        description: "Dispatch GitHub App client id (dispatches into geolonia-operations)."
+        required: true
+      OPS_DISPATCH_APP_PRIVATE_KEY:
+        description: "Dispatch GitHub App private key."
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Forward issue field change to operations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Generate dispatch token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.OPS_DISPATCH_CLIENT_ID }}
+          private-key: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
+          repositories: ${{ inputs.operations_repo }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Dispatch routing request
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          TARGET: ${{ github.repository_owner }}/${{ inputs.operations_repo }}
+          EVENT_TYPE: ${{ inputs.event_type }}
+          SOURCE_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ACTION: ${{ github.event.action }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ISSUE_NODE_ID:-}" ]; then
+            echo "::error::No issue node id in event payload; nothing to dispatch."
+            exit 1
+          fi
+
+          REQUEST_BODY=$(jq -n \
+            --arg event_type "$EVENT_TYPE" \
+            --arg repo "$SOURCE_REPO" \
+            --arg number "$ISSUE_NUMBER" \
+            --arg node_id "$ISSUE_NODE_ID" \
+            --arg url "$ISSUE_URL" \
+            --arg action "$ACTION" \
+            '{
+              event_type: $event_type,
+              client_payload: {
+                source_repo: $repo,
+                issue_number: $number,
+                issue_node_id: $node_id,
+                issue_url: $url,
+                action: $action
+              }
+            }')
+
+          echo "$REQUEST_BODY" | gh api "repos/${TARGET}/dispatches" --input -
+
+          echo "::notice::Dispatched ${ACTION} for ${SOURCE_REPO}#${ISSUE_NUMBER} to ${TARGET}"

--- a/.github/workflows/reusable-route-issue.yml
+++ b/.github/workflows/reusable-route-issue.yml
@@ -81,6 +81,9 @@ jobs:
           private-key: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
           repositories: ${{ inputs.operations_repo }}
           owner: ${{ github.repository_owner }}
+          # Least privilege: repository_dispatch needs only these scopes.
+          permission-metadata: read
+          permission-contents: write
 
       - name: Dispatch routing request
         env:

--- a/.github/workflows/reusable-route-issue.yml
+++ b/.github/workflows/reusable-route-issue.yml
@@ -45,6 +45,13 @@ on:
         type: string
         required: false
         default: "route-issue"
+      remove_on_field_removed:
+        description: >-
+          When this repo's Department field is cleared, also remove the issue
+          from its team board(s). Default: keep the issue on the board.
+        type: boolean
+        required: false
+        default: false
     secrets:
       OPS_DISPATCH_CLIENT_ID:
         description: "Dispatch GitHub App client id (dispatches into geolonia-operations)."
@@ -81,6 +88,7 @@ jobs:
           ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ACTION: ${{ github.event.action }}
+          REMOVE_ON_FIELD_REMOVED: ${{ inputs.remove_on_field_removed }}
         shell: bash
         run: |
           set -euo pipefail
@@ -97,6 +105,7 @@ jobs:
             --arg node_id "$ISSUE_NODE_ID" \
             --arg url "$ISSUE_URL" \
             --arg action "$ACTION" \
+            --argjson remove "$REMOVE_ON_FIELD_REMOVED" \
             '{
               event_type: $event_type,
               client_payload: {
@@ -104,7 +113,8 @@ jobs:
                 issue_number: $number,
                 issue_node_id: $node_id,
                 issue_url: $url,
-                action: $action
+                action: $action,
+                remove_on_field_removed: $remove
               }
             }')
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -13,6 +13,7 @@ under `.github/workflows/`.
 | Bumblebee Supply-Chain Scan (`bumblebee-scan.yml`) | [Bumblebee Supply-Chain Scan](workflows/bumblebee-scan.md) |
 | Action Pinning Check (`pinact-check.yml`) | [Action Pinning Check](workflows/pinact-check.md) |
 | CDK Deploy Monitor (`cdk-deploy-monitor.yml`) | [CDK Deploy Monitor](workflows/cdk-deploy-monitor.md) |
+| Route issue to team board (`route-issue.yml`) | [Route issue to team board](workflows/route-issue.md) |
 
 ## Why two workflow locations?
 

--- a/docs/workflows/route-issue.md
+++ b/docs/workflows/route-issue.md
@@ -33,7 +33,7 @@ jobs:
 
 | Input | Default | Effect |
 | --- | --- | --- |
-| `remove_on_field_removed` | `false` | When the issue's `Department` field is **cleared**, also remove the issue from its team board(s). Default keeps it on the board. |
+| `exclusive_routing` | `true` | Keep each issue on only the board for its **current** `Department`. Changing the department moves the issue off the other department boards; clearing it removes the issue from all of them. Set `false` for additive routing (add only, never remove). |
 
 ```yaml
 jobs:
@@ -41,13 +41,21 @@ jobs:
     uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
     secrets: inherit
     with:
-      remove_on_field_removed: true
+      exclusive_routing: false   # add only, never remove
 ```
 
-Removal only fires when the field is **cleared**. Changing `Department` from one
-option to another fires `field_added` (an update), not `field_removed`, so a
-move between boards adds to the new board without removing the old item. A
-configured master board is never removed from.
+With the default (`exclusive_routing: true`), fixing a mis-set department also
+cleans up: picking the wrong option then correcting it leaves the issue on only
+the corrected board, not both.
+
+**Only department boards are ever touched.** Removal is scoped strictly to the
+projects listed under `departments` in `geolonia-operations`' `routing.yml`. A
+configured master/all-work board and any unrelated project an issue happens to
+sit on are never removed from.
+
+One residual edge: if the department is changed to an option that has **no
+board yet** (unmapped), the issue is left where it is and a warning is logged
+(there is no destination to move it to).
 
 ## Why dispatch-to-central?
 

--- a/docs/workflows/route-issue.md
+++ b/docs/workflows/route-issue.md
@@ -1,0 +1,81 @@
+# Route issue to team board (`route-issue.yml`)
+
+Opt a repo in to **org-wide issue auto-routing**: when an issue's org-level
+`Department` issue field is set, the issue is added to the matching team
+project board (Operations, Security, … Design later). The issue stays in its
+home repo and can sit on multiple boards at once.
+
+- Runs on `issues: [field_added, field_removed]` in the participating repo.
+- Delegates to `reusable-route-issue.yml@v1`, which forwards the event to the
+  private `geolonia-operations` repo via `repository_dispatch`.
+- No per-repo configuration. The routing table (`Department → project`) and the
+  privileged Org-Projects token live **only** in `geolonia-operations`.
+
+Example minimal usage after selecting the template:
+
+```yaml
+name: Route issue to team board
+
+on:
+  issues:
+    types: [field_added, field_removed]
+
+permissions:
+  contents: read
+
+jobs:
+  route:
+    uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
+    secrets: inherit
+```
+
+## Why dispatch-to-central?
+
+This public side is a dumb forwarder. It mints only a low-privilege dispatch
+token and tells `geolonia-operations` "issue node id X changed". It never reads
+the field value, never sees a project id, and never holds the Org-Projects
+credential. That keeps every secret and routing decision private, mirroring the
+[Sync Team Access](../workflows.md) dispatch-to-central design (individual repos
+never see the org token).
+
+```text
+participating repo            geolonia/.github (public)        geolonia-operations (private)
+route-issue.yml  ──uses──▶  reusable-route-issue.yml
+ on: issues:                  mint dispatch token
+  [field_added,               repository_dispatch ──────────▶  process-route-issue.yml
+   field_removed]                                              read Department → add to board
+```
+
+## Prerequisites
+
+- The repo must be able to see the org dispatch secrets
+  `OPS_DISPATCH_CLIENT_ID` and `OPS_DISPATCH_APP_PRIVATE_KEY` (org-level Actions
+  secrets, already used by Sync Team Access).
+- The caller workflow must live on the repo's **default branch**, otherwise the
+  `issues` trigger does not fire.
+
+## Troubleshooting
+
+### Issue field set but nothing lands on the board
+
+1. Confirm the caller workflow is on the **default branch** and ran (Actions tab
+   of the participating repo).
+2. Confirm the dispatch step succeeded and check that the matching
+   `repository_dispatch` run started in `geolonia-operations`
+   (**Actions → Route Issue to Team Board**).
+3. Confirm the `Department` option name exists in `geolonia-operations`'
+   `scripts/route-issue/routing.yml`. An unmapped department is logged and
+   skipped, not an error.
+
+### Dispatch step fails with a token/permission error
+
+The org dispatch secrets must be visible to the calling repo (check org secret
+visibility) and the dispatch app must be installed on `geolonia-operations`.
+
+See also the general [Troubleshooting](../workflows.md#troubleshooting) section
+for log-fetching tips.
+
+> Issue fields are in **public preview**. The single field-value read is
+> isolated in `geolonia-operations`' `scripts/route-issue/route.sh`, so a
+> preview API change is a one-line edit there with no impact on participating
+> repos.

--- a/docs/workflows/route-issue.md
+++ b/docs/workflows/route-issue.md
@@ -29,6 +29,26 @@ jobs:
     secrets: inherit
 ```
 
+## Options
+
+| Input | Default | Effect |
+| --- | --- | --- |
+| `remove_on_field_removed` | `false` | When the issue's `Department` field is **cleared**, also remove the issue from its team board(s). Default keeps it on the board. |
+
+```yaml
+jobs:
+  route:
+    uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
+    secrets: inherit
+    with:
+      remove_on_field_removed: true
+```
+
+Removal only fires when the field is **cleared**. Changing `Department` from one
+option to another fires `field_added` (an update), not `field_removed`, so a
+move between boards adds to the new board without removing the old item. A
+configured master board is never removed from.
+
 ## Why dispatch-to-central?
 
 This public side is a dumb forwarder. It mints only a low-privilege dispatch

--- a/docs/workflows/route-issue.md
+++ b/docs/workflows/route-issue.md
@@ -49,9 +49,8 @@ cleans up: picking the wrong option then correcting it leaves the issue on only
 the corrected board, not both.
 
 **Only department boards are ever touched.** Removal is scoped strictly to the
-projects listed under `departments` in `geolonia-operations`' `routing.yml`. A
-configured master/all-work board and any unrelated project an issue happens to
-sit on are never removed from.
+projects listed under `departments` in `geolonia-operations`' `routing.yml`. Any
+other project an issue happens to sit on is never removed from.
 
 One residual edge: if the department is changed to an option that has **no
 board yet** (unmapped), the issue is left where it is and a warning is logged

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
       - Bumblebee Supply-Chain Scan: workflows/bumblebee-scan.md
       - Action Pinning Check: workflows/pinact-check.md
       - CDK Deploy Monitor: workflows/cdk-deploy-monitor.md
+      - Route issue to team board: workflows/route-issue.md
   - GitHub Actions Pinning: github-actions-pinning.md
   - Organization Profile: profile.md
 docs_dir: docs

--- a/workflow-templates/route-issue.properties.json
+++ b/workflow-templates/route-issue.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Route issue to team board",
+  "description": "When an issue's org Department field is set, add the issue to the matching team project board. Routing config and credentials stay private in geolonia-operations; this repo only forwards the event.",
+  "iconName": "book",
+  "categories": ["Automation"],
+  "filePatterns": [".github/workflows/.*"]
+}

--- a/workflow-templates/route-issue.yml
+++ b/workflow-templates/route-issue.yml
@@ -21,7 +21,7 @@ jobs:
     #
     # By default each issue stays on only the board for its current Department
     # (changing/clearing the field moves it off the other department boards;
-    # master and unrelated boards are never touched). For additive routing
-    # (add only, never remove):
+    # projects that are not department boards are never touched). For additive
+    # routing (add only, never remove):
     # with:
     #   exclusive_routing: false

--- a/workflow-templates/route-issue.yml
+++ b/workflow-templates/route-issue.yml
@@ -18,3 +18,8 @@ jobs:
     # Must live on the DEFAULT branch for the issues trigger to fire. Requires
     # the org dispatch secrets (OPS_DISPATCH_CLIENT_ID /
     # OPS_DISPATCH_APP_PRIVATE_KEY) to be visible to this repo.
+    #
+    # Opt in to removing the issue from its board when the Department field is
+    # cleared (default: keep it on the board):
+    # with:
+    #   remove_on_field_removed: true

--- a/workflow-templates/route-issue.yml
+++ b/workflow-templates/route-issue.yml
@@ -1,0 +1,20 @@
+name: Route issue to team board
+
+on:
+  issues:
+    types: [field_added, field_removed]
+
+permissions:
+  contents: read
+
+jobs:
+  route:
+    uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
+    secrets: inherit
+    # When this repo's issues get an org Department field value, they are added
+    # to the matching team project board. Routing config and credentials stay
+    # private in geolonia-operations; this repo only forwards the event.
+    #
+    # Must live on the DEFAULT branch for the issues trigger to fire. Requires
+    # the org dispatch secrets (OPS_DISPATCH_CLIENT_ID /
+    # OPS_DISPATCH_APP_PRIVATE_KEY) to be visible to this repo.

--- a/workflow-templates/route-issue.yml
+++ b/workflow-templates/route-issue.yml
@@ -19,7 +19,9 @@ jobs:
     # the org dispatch secrets (OPS_DISPATCH_CLIENT_ID /
     # OPS_DISPATCH_APP_PRIVATE_KEY) to be visible to this repo.
     #
-    # Opt in to removing the issue from its board when the Department field is
-    # cleared (default: keep it on the board):
+    # By default each issue stays on only the board for its current Department
+    # (changing/clearing the field moves it off the other department boards;
+    # master and unrelated boards are never touched). For additive routing
+    # (add only, never remove):
     # with:
-    #   remove_on_field_removed: true
+    #   exclusive_routing: false


### PR DESCRIPTION
Closes #56

## What

Public **dispatch leg** for org-wide issue auto-routing (Phase 1). Lets any
Geolonia repo opt in to having its issues auto-added to a team project board
based on the org `Department` issue field — without exposing any credential or
routing config publicly.

### Files
- `.github/workflows/reusable-route-issue.yml` — reusable workflow: mints the
  low-priv `OPS_DISPATCH` app token and `repository_dispatch`es the issue to
  `geolonia-operations`.
- `workflow-templates/route-issue.yml` + `.properties.json` — one-click adoption
  in the **New workflow** picker (thin caller on `issues:[field_added,field_removed]`).
- `docs/workflows/route-issue.md` + nav/table entry.

## Why dispatch-to-central

Mirrors the existing `sync-team-access` pattern — *individual repos never see
the org token*. This public side is a dumb forwarder: no project IDs, no routing
logic, no privileged token. All of that lives in private `geolonia-operations`
(see geolonia/geolonia-operations#156, the receiver half).

## Notes
- Reuses the existing `OPS_DISPATCH_CLIENT_ID` / `OPS_DISPATCH_APP_PRIVATE_KEY`
  org secrets (already wired for `sync-team-access`).
- Actions SHA-pinned to the same `create-github-app-token` SHA the repo already uses (`pinact` clean).
- Caller pins the reusable workflow to `@v1` — **a `v1` tag must exist** before consumers adopt it (cut after merge, per `release-auto-on-tag`).

## Not in this PR
- The privileged receiver, `routing.yml`, and the "Issue Router" GitHub App live in `geolonia-operations`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable workflow to forward issue events to a central operations repo for org-wide board routing.
  * Workflow template to opt repositories into automatic issue routing, with optional exclusive vs additive routing.

* **Documentation**
  * Added setup guide, behavior notes, troubleshooting tips, and a new Workflows navigation entry for the routing template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->