### PR TITLE
Add workflow to route issues to team board

### DIFF
--- a/.github/workflows/route-issue.yml
+++ b/.github/workflows/route-issue.yml
@@ -1,0 +1,27 @@
+name: Route issue to team board
+
+on:
+  issues:
+    types: [field_added, field_removed]
+
+permissions:
+  contents: read
+
+jobs:
+  route:
+    uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
+    secrets: inherit
+    # When this repo's issues get an org Department field value, they are added
+    # to the matching team project board. Routing config and credentials stay
+    # private in geolonia-operations; this repo only forwards the event.
+    #
+    # Must live on the DEFAULT branch for the issues trigger to fire. Requires
+    # the org dispatch secrets (OPS_DISPATCH_CLIENT_ID /
+    # OPS_DISPATCH_APP_PRIVATE_KEY) to be visible to this repo.
+    #
+    # By default each issue stays on only the board for its current Department
+    # (changing/clearing the field moves it off the other department boards;
+    # projects that are not department boards are never touched). For additive
+    # routing (add only, never remove):
+    # with:
+    #   exclusive_routing: false

--- a/.github/workflows/route-issue.yml
+++ b/.github/workflows/route-issue.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   route:
-    uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     secrets: inherit
     # When this repo's issues get an org Department field value, they are added
     # to the matching team project board. Routing config and credentials stay


### PR DESCRIPTION
This workflow routes issues to the team board based on field changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automation to route issue field changes to the appropriate team board.
  * Ensures required dispatch secrets are forwarded so routing runs reliably and preserves expected department-routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->