### PR TITLE
ci: SHA-pin all workflow templates so UI adoption is pinact-clean

### DIFF
--- a/.pinact.yml
+++ b/.pinact.yml
@@ -35,6 +35,21 @@
 # locally. Do not hand-edit the SHA or the version comment; pinact keeps
 # the two in sync.
 version: 3
+# Besides this repo's own workflows, also verify the GitHub Actions pinned in the
+# org workflow templates served by the "New workflow" picker (workflow-templates/).
+# The picker copies these files verbatim, so they must already be SHA-pinned for
+# an adopting repo's Action Pinning Check to pass on first commit. Dependabot's
+# github-actions ecosystem only scans .github/workflows, so it cannot reach these
+# template files; this check covers them here, catching any unpinned or
+# comment-mismatched ref at PR time. Setting `files` replaces pinact's default
+# list, so the default workflow and composite-action patterns are repeated first.
+files:
+  - pattern: .github/workflows/*.yml
+  - pattern: .github/workflows/*.yaml
+  - pattern: .github/actions/*/action.yml
+  - pattern: .github/actions/*/action.yaml
+  - pattern: workflow-templates/*.yml
+  - pattern: workflow-templates/*.yaml
 min_age:
   value: 7
   always: true

--- a/workflow-templates/bumblebee-scan.yml
+++ b/workflow-templates/bumblebee-scan.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   scan:
-    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     # Default: project profile, all ecosystems, fail PR on any match.
     # Common overrides:
     # with:

--- a/workflow-templates/cdk-deploy-monitor.yml
+++ b/workflow-templates/cdk-deploy-monitor.yml
@@ -14,7 +14,7 @@ jobs:
   # ... your existing deploy job here ...
 
   monitor:
-    uses: geolonia/.github/.github/workflows/reusable-cdk-deploy-monitor.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-cdk-deploy-monitor.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     with:
       stack_name: MyAppStack        # CloudFormation stack name
       aws_region: ap-northeast-1   # AWS region

--- a/workflow-templates/pinact-check.yml
+++ b/workflow-templates/pinact-check.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   pinact:
-    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     # Verifies every GitHub Action in this repo is SHA-pinned, carries a
     # matching version comment, and meets the 7-day minimum release age.
     # Requires a .pinact.yml at the repo root (copy the org canonical one

--- a/workflow-templates/publish-techdocs.yml
+++ b/workflow-templates/publish-techdocs.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     secrets: inherit
     # optional inputs can be specified here to override defaults
     # with:

--- a/workflow-templates/release-auto-on-tag.yml
+++ b/workflow-templates/release-auto-on-tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    uses: geolonia/.github/.github/workflows/reusable-release-auto-on-tag.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-release-auto-on-tag.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     secrets: inherit
     # Optional settings (uncomment to override defaults):
     # with:

--- a/workflow-templates/route-issue.yml
+++ b/workflow-templates/route-issue.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   route:
-    uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     secrets: inherit
     # When this repo's issues get an org Department field value, they are added
     # to the matching team project board. Routing config and credentials stay

--- a/workflow-templates/secret-leak-check.yml
+++ b/workflow-templates/secret-leak-check.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   scan:
-    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     # The default behaviour scans the PR diff with every betterleaks
     # detector enabled. If a false positive shows up, commit a
     # .betterleaks.toml at the repo root with a documented allowlist and

--- a/workflow-templates/sync-team-access.yml
+++ b/workflow-templates/sync-team-access.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync:
-    uses: geolonia/.github/.github/workflows/reusable-sync-team-access.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-sync-team-access.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     secrets: inherit
     # Optional settings (uncomment to override defaults):
     # with:


### PR DESCRIPTION
Closes #59

## What

SHA-pins every **"New workflow (by Geolonia)"** template so adopting one via the
GitHub UI produces a pinact-clean PR with no manual `pinact run`.

- All 8 `workflow-templates/*.yml` `uses:` refs: `@v1` → `@92c8c6d # v1.16.0`.
- `.pinact.yml`: add a `files:` list (defaults + `workflow-templates/*`) so the
  templates themselves are now verified by the Action Pinning Check.

## Why

The picker copies templates verbatim and GitHub can't pin at add-time, so `@v1`
made every UI adoption fail the adopter's pinact gate. `geolonia/*` is already
min-age-exempt, so pinning to a fresh release is allowed. Each adopting repo's
Dependabot bumps its own copy from there.

## Verification

`pinact run --fix=false --verify --verify-min-age` → exit 0 locally (and this
PR's own Action Pinning Check now covers the templates).

## Follow-up (not in this PR)

Dependabot can't scan `workflow-templates/`, so these template SHAs won't
auto-update. A release-time job that re-pins `workflow-templates/` on each new
tag would keep them fresh — happy to add it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Pinned GitHub Actions workflow versions to specific commits (v1.16.0) instead of floating version tags to ensure deterministic and consistent execution across environments.
* Expanded workflow file configuration to comprehensively include all workflow templates and action manifests for complete coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->