### PR TITLE
docs(route-issue): simplify page, picker description + template comments

### DIFF
--- a/docs/workflows/route-issue.md
+++ b/docs/workflows/route-issue.md
@@ -42,9 +42,8 @@ jobs:
 
 - The workflow must live on the repo's **default branch**, or the `issues`
   trigger won't fire.
-- The repo needs access to the shared org dispatch secrets (already used by
-  [Sync Team Access](../workflows.md)). Repos created from the standard
-  scaffolder get this automatically.
+- The repo needs access to the org's shared dispatch secrets (org-level Actions
+  secrets). Repos created from the standard scaffolder get this automatically.
 
 ## Troubleshooting
 

--- a/docs/workflows/route-issue.md
+++ b/docs/workflows/route-issue.md
@@ -1,17 +1,11 @@
 # Route issue to team board (`route-issue.yml`)
 
-Opt a repo in to **org-wide issue auto-routing**: when an issue's org-level
-`Department` issue field is set, the issue is added to the matching team
-project board (Operations, Security, … Design later). The issue stays in its
-home repo and can sit on multiple boards at once.
+Opt a repo in to **issue auto-routing**: when you set an issue's org `Department`
+field, the issue is added to that team's project board. The issue stays in its
+home repo, and no per-repo configuration is needed.
 
-- Runs on `issues: [field_added, field_removed]` in the participating repo.
-- Delegates to `reusable-route-issue.yml@v1`, which forwards the event to the
-  private `geolonia-operations` repo via `repository_dispatch`.
-- No per-repo configuration. The routing table (`Department → project`) and the
-  privileged Org-Projects token live **only** in `geolonia-operations`.
-
-Example minimal usage after selecting the template:
+Add it from **Actions → New workflow → "Route issue to team board"**, on the
+repo's default branch. Minimal form:
 
 ```yaml
 name: Route issue to team board
@@ -33,7 +27,7 @@ jobs:
 
 | Input | Default | Effect |
 | --- | --- | --- |
-| `exclusive_routing` | `true` | Keep each issue on only the board for its **current** `Department`. Changing the department moves the issue off the other department boards; clearing it removes the issue from all of them. Set `false` for additive routing (add only, never remove). |
+| `exclusive_routing` | `true` | Keep each issue on only its **current** department's board: changing the field moves it to the new board, and clearing it removes it. Set `false` to only ever add (never remove). |
 
 ```yaml
 jobs:
@@ -44,65 +38,22 @@ jobs:
       exclusive_routing: false   # add only, never remove
 ```
 
-With the default (`exclusive_routing: true`), fixing a mis-set department also
-cleans up: picking the wrong option then correcting it leaves the issue on only
-the corrected board, not both.
+## Requirements
 
-**Only department boards are ever touched.** Removal is scoped strictly to the
-projects listed under `departments` in `geolonia-operations`' `routing.yml`. Any
-other project an issue happens to sit on is never removed from.
-
-One residual edge: if the department is changed to an option that has **no
-board yet** (unmapped), the issue is left where it is and a warning is logged
-(there is no destination to move it to).
-
-## Why dispatch-to-central?
-
-This public side is a dumb forwarder. It mints only a low-privilege dispatch
-token and tells `geolonia-operations` "issue node id X changed". It never reads
-the field value, never sees a project id, and never holds the Org-Projects
-credential. That keeps every secret and routing decision private, mirroring the
-[Sync Team Access](../workflows.md) dispatch-to-central design (individual repos
-never see the org token).
-
-```text
-participating repo            geolonia/.github (public)        geolonia-operations (private)
-route-issue.yml  ──uses──▶  reusable-route-issue.yml
- on: issues:                  mint dispatch token
-  [field_added,               repository_dispatch ──────────▶  process-route-issue.yml
-   field_removed]                                              read Department → add to board
-```
-
-## Prerequisites
-
-- The repo must be able to see the org dispatch secrets
-  `OPS_DISPATCH_CLIENT_ID` and `OPS_DISPATCH_APP_PRIVATE_KEY` (org-level Actions
-  secrets, already used by Sync Team Access).
-- The caller workflow must live on the repo's **default branch**, otherwise the
-  `issues` trigger does not fire.
+- The workflow must live on the repo's **default branch**, or the `issues`
+  trigger won't fire.
+- The repo needs access to the shared org dispatch secrets (already used by
+  [Sync Team Access](../workflows.md)). Repos created from the standard
+  scaffolder get this automatically.
 
 ## Troubleshooting
 
-### Issue field set but nothing lands on the board
+Issue field set but nothing appears on the board:
 
-1. Confirm the caller workflow is on the **default branch** and ran (Actions tab
-   of the participating repo).
-2. Confirm the dispatch step succeeded and check that the matching
-   `repository_dispatch` run started in `geolonia-operations`
-   (**Actions → Route Issue to Team Board**).
-3. Confirm the `Department` option name exists in `geolonia-operations`'
-   `scripts/route-issue/routing.yml`. An unmapped department is logged and
-   skipped, not an error.
+1. Confirm the workflow is on the **default branch** and that its run succeeded
+   (Actions tab).
+2. The board for that department must exist. Setting a department that has no
+   board yet is logged and skipped, not an error.
 
-### Dispatch step fails with a token/permission error
-
-The org dispatch secrets must be visible to the calling repo (check org secret
-visibility) and the dispatch app must be installed on `geolonia-operations`.
-
-See also the general [Troubleshooting](../workflows.md#troubleshooting) section
-for log-fetching tips.
-
-> Issue fields are in **public preview**. The single field-value read is
-> isolated in `geolonia-operations`' `scripts/route-issue/route.sh`, so a
-> preview API change is a one-line edit there with no impact on participating
-> repos.
+See the general [Troubleshooting](../workflows.md#troubleshooting) section for
+log-fetching tips.

--- a/workflow-templates/route-issue.properties.json
+++ b/workflow-templates/route-issue.properties.json
@@ -1,6 +1,6 @@
 {
   "name": "Route issue to team board",
-  "description": "When an issue's org Department field is set, add the issue to the matching team project board. Routing config and credentials stay private in geolonia-operations; this repo only forwards the event.",
+  "description": "When you set an issue's org Department field, the issue is added to that team's project board.",
   "iconName": "book",
   "categories": ["Automation"],
   "filePatterns": [".github/workflows/.*"]

--- a/workflow-templates/route-issue.yml
+++ b/workflow-templates/route-issue.yml
@@ -11,17 +11,11 @@ jobs:
   route:
     uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     secrets: inherit
-    # When this repo's issues get an org Department field value, they are added
-    # to the matching team project board. Routing config and credentials stay
-    # private in geolonia-operations; this repo only forwards the event.
+    # When you set an issue's org Department field, the issue is added to that
+    # team's project board. Keep this workflow on the default branch so the
+    # issues trigger fires.
     #
-    # Must live on the DEFAULT branch for the issues trigger to fire. Requires
-    # the org dispatch secrets (OPS_DISPATCH_CLIENT_ID /
-    # OPS_DISPATCH_APP_PRIVATE_KEY) to be visible to this repo.
-    #
-    # By default each issue stays on only the board for its current Department
-    # (changing/clearing the field moves it off the other department boards;
-    # projects that are not department boards are never touched). For additive
-    # routing (add only, never remove):
+    # By default each issue stays on only its current department's board.
+    # Set exclusive_routing: false to only ever add (never remove):
     # with:
     #   exclusive_routing: false


### PR DESCRIPTION
Simplifies all user-facing `route-issue` text to the adopter's perspective.

**`docs/workflows/route-issue.md`**, **`workflow-templates/route-issue.properties.json`** (picker description), and **`workflow-templates/route-issue.yml`** (inline comments).

**Removed:** dispatch-to-central explanation + flow diagram, preview-API note, token/secret names, and hardcoded department/project names (Operations/Security/Design).

**Kept:** what it does, how to add it (picker, default branch), the `exclusive_routing` option, and short troubleshooting.

The SHA pin in the template is unchanged (pinact stays green); routing config and the Design board stay in `geolonia-operations`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue auto-routing workflow documentation to clarify opt-in behavior through organization Department field configuration.
  * Simplified routing option descriptions to better explain exclusive vs. additive routing modes.
  * Streamlined requirements and troubleshooting guidance for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->