### PR TITLE
chore(pinact): bump example CLI install hint to v4.1.0

### DIFF
--- a/pinact/.pre-commit-config.example.yaml
+++ b/pinact/.pre-commit-config.example.yaml
@@ -14,7 +14,7 @@
 # consistent between local and CI.
 #
 # pinact must be on PATH. Install it with Homebrew (above), aqua, or
-# `go install github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.0.0`.
+# `go install github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.1.0`.
 # Pin the same v4 line that the CI gate (pinact-action v3) bundles, so
 # local and CI use the same engine.
 #


### PR DESCRIPTION
## What

Bumps the `go install` hint in `pinact/.pre-commit-config.example.yaml` from `@v4.0.0` to `@v4.1.0`, the current pinact v4 line.

## Why

Tracking issue: geolonia/geolonia-operations#167 (pinact v4.1.0 available, past the 7-day cooldown).

The pinact **CLI** is the thing that issue tracks, and it is not functionally version-pinned anywhere in our setup:

- **CI gate** uses `suzuki-shunsuke/pinact-action@v3.0.0` (bundles its own pinact binary), already Dependabot-maintained.
- **Local installs** are unpinned (`brew install pinact` / aqua pull latest), so `brew upgrade pinact` already gets v4.1.0.
- **`.pinact.yml` schema** `version: 3` is tied to the v4 **major**; v4.1.0 is a minor, so it stays at `3`.

So the only stale literal is the documentation install hint. This keeps it matching the current line.

## Scope / risk

Comment-only change in an example file. No workflow, action pin, or config schema is affected. v4.1.0 changelog is a single internal item (`ghtkn-go-sdk` to v0.3.0, disables device flow); no behavior change to the pin/verify path we use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example configuration to reflect current version recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->