### PR TITLE
chore(betterleaks): bump pinned image to v1.5.0

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -23,7 +23,7 @@ on:
         description: "betterleaks container image, pinned by digest. Override only for testing newer versions."
         type: string
         required: false
-        default: "ghcr.io/betterleaks/betterleaks@sha256:1edd658874fbbd42fe224b7b0ccff32acc5940dd0098ad651caf32998462bff7"  # v1.4.1 -- fixes the Go 1.25 taggedPointerPack crash on linux/amd64 that affected v1.3.1..v1.4.0.
+        default: "ghcr.io/betterleaks/betterleaks@sha256:e78fa87a9113506302d7f08698f8e1065c8c5bb363e43b2db058ea4464189922"  # v1.5.0 -- 50 new detection rules; archives scanned by default. Org default.toml verified to parse under the new go-toml config loader.
       fail-on-findings:
         description: "Fail the job (block the PR check) when secrets are found. Set false for warn-only mode while a repo cleans up legacy false positives."
         type: boolean

--- a/betterleaks/.pre-commit-config.example.yaml
+++ b/betterleaks/.pre-commit-config.example.yaml
@@ -22,7 +22,7 @@ repos:
   - repo: https://github.com/betterleaks/betterleaks
     # Pin to the same version as the per-PR Secret Leak Check workflow.
     # Bump both together so local and CI use identical rule shapes.
-    rev: v1.3.0
+    rev: v1.5.0
     hooks:
       # Docker variant. Works without a local Go/Rust toolchain. The image
       # is pulled on first use and cached. Mac/Linux developers typically


### PR DESCRIPTION
## What

- Per-PR **Secret Leak Check** default image: `v1.4.1` -> `v1.5.0` (`sha256:e78fa87a...189922`).
- Pre-commit example `rev`: `v1.3.0` -> `v1.5.0` (it had drifted behind CI; the file's own comment says to keep them in lockstep).

Tracking issue: geolonia/geolonia-operations#177 (past the 7-day cooldown; v1.5.0 published 2026-06-12).

## Digest provenance

`v1.5.0` resolves to `sha256:e78fa87a9113506302d7f08698f8e1065c8c5bb363e43b2db058ea4464189922` (ghcr.io manifest index digest). Method sanity-checked: the same resolution returns `sha256:1edd658...462bff7` for `v1.4.1`, matching the digest pinned today.

## Compatibility validation

v1.5.0 isn't purely additive — it migrates config parsing from spf13/viper to go-toml (#191) and enables archive scanning by default. Since viper lowercases keys and go-toml is case-sensitive, the camelCase keys in our org `betterleaks/default.toml` (`useDefault`, `disabledRules`) were a real regression risk. I ran v1.5.0 against the actual org config:

- ✅ Config parses under go-toml (no error).
- ✅ `disabledRules = ["generic-api-key"]` honored — a generic high-entropy `api_key` line did **not** fire.
- ✅ Allowlists applied — a `YOUR_API_KEY` placeholder suppressed.
- ✅ Targeted detection intact — `slack-bot-token` fired.

## Behavior change to expect

Archive handling is now on by default. For the weekly audit this just means more thorough coverage (it's non-blocking, `--exit-code 0`). Pass `--max-archive-depth=0` to restore old behavior if needed.

## Note

A companion PR in `geolonia-operations` bumps the weekly org-wide audit's `BETTERLEAKS_IMAGE` and the docs example to the same digest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated betterleaks tool to v1.5.0 across CI/CD pipelines and local development configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->