### PR TITLE
chore(deps): bump bumblebee default to v0.1.2

### DIFF
--- a/.github/workflows/reusable-bumblebee-scan.yml
+++ b/.github/workflows/reusable-bumblebee-scan.yml
@@ -26,7 +26,7 @@ on:
         description: "Bumblebee release tag (also the source for `threat_intel/`)."
         type: string
         required: false
-        default: "v0.1.1"
+        default: "v0.1.2"
       fail-on-findings:
         description: "Fail the job when exposures are matched. Set false for warn-only mode."
         type: boolean

--- a/docs/workflows/bumblebee-scan.md
+++ b/docs/workflows/bumblebee-scan.md
@@ -39,7 +39,7 @@ configurations and editor / browser extensions in the repo checkout.
 
 | Input | Default | Purpose |
 | --- | --- | --- |
-| `bumblebee-version` | `v0.1.1` | Upstream release tag. Also the source for the `threat_intel/` catalog. |
+| `bumblebee-version` | `v0.1.2` | Upstream release tag. Also the source for the `threat_intel/` catalog. |
 | `fail-on-findings` | `true` | Set to `false` for warn-only mode while triaging. |
 | `ecosystems` | (all) | Comma-separated list to scope the scan, for example `npm,mcp`. |
 | `profile` | `project` | One of `baseline`, `project`, or `deep`. |

--- a/workflow-templates/bumblebee-scan.yml
+++ b/workflow-templates/bumblebee-scan.yml
@@ -25,5 +25,5 @@ jobs:
     # with:
     #   ecosystems: "npm,mcp"            # scope to specific ecosystems
     #   fail-on-findings: false          # warn-only while triaging
-    #   bumblebee-version: "v0.1.1"      # pin a different release
+    #   bumblebee-version: "v0.1.2"      # pin a specific release
     #   profile: "baseline"              # baseline | project | deep


### PR DESCRIPTION
## What

Bump the `bumblebee-version` default in `reusable-bumblebee-scan.yml` from `v0.1.1` to `v0.1.2`.

## Why

v0.1.2 is primarily a threat-intelligence and scanner-coverage release. Because the bundled `threat_intel/` catalog ships with the release, every caller repo inheriting the default picks up:

- New exposure catalogs: GlassWorm, Mastra npm supply-chain, Mini Shai-Hulud (Red Hat Cloud Services), TrapDoor Crypto Stealer, Laravel Lang
- New scanners: Homebrew packages, agent-skill (skills.sh lock files), MCP server inventory (`~/.claude.json`)
- Wider version coverage (700 tags) and catalog metadata cleanup

No breaking changes are noted upstream. Release notes: https://github.com/perplexityai/bumblebee/releases/tag/v0.1.2

## Changes

- `reusable-bumblebee-scan.yml`: default `v0.1.1` to `v0.1.2`
- `docs/workflows/bumblebee-scan.md`: inputs table default updated to match
- `workflow-templates/bumblebee-scan.yml`: example override comment refreshed

## Test plan

- No behaviour change beyond the downloaded release asset; the asset name is derived from the version input (`bumblebee_<ver>_linux_amd64.tar.gz`).
- actionlint / yamllint on the changed workflow.
- Caller repos pick up the new default on their next scheduled scan; pinning an explicit `bumblebee-version` still overrides it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default bundled scan version to a newer release, so new runs use the latest available content by default.
* **Documentation**
  * Aligned the workflow documentation and template examples with the updated default version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->