### PR TITLE
ci(techdocs): make publish-techdocs template standalone by default

### DIFF
--- a/docs/workflows/publish-techdocs.md
+++ b/docs/workflows/publish-techdocs.md
@@ -7,6 +7,10 @@
   optional inputs allow setting a repo secret `AWS_ACCOUNT_ID` to override on a
   per-repo basis.
 
+The template is standalone by default (`push` on `docs/**` plus
+`workflow_dispatch`). Pass the AWS account secrets explicitly rather than
+`secrets: inherit`, so the reusable receives only what it needs.
+
 Example minimal usage after selecting the template:
 
 ```yaml
@@ -17,11 +21,15 @@ jobs:
     # with:
     #   environment: production
     #   aws_region: ap-northeast-1
-    secrets: inherit
-    # In case you want to override the AWS account ID:
-    # secrets: 
-    #   AWS_ACCOUNT_ID: ${{ secrets.TECHDOCS_AWS_ACCOUNT_ID }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      TECHDOCS_AWS_ACCOUNT_ID: ${{ secrets.TECHDOCS_AWS_ACCOUNT_ID }}
 ```
+
+To also publish docs as part of a release (called from `publish-release.yml`),
+add a `workflow_call` trigger that declares an explicit `secrets` contract
+(`AWS_ACCOUNT_ID` and `TECHDOCS_AWS_ACCOUNT_ID`, both `required: false`) and
+have the caller pass them explicitly.
 
 ## Troubleshooting
 

--- a/workflow-templates/publish-techdocs.yml
+++ b/workflow-templates/publish-techdocs.yml
@@ -7,12 +7,27 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
   workflow_dispatch:
-  workflow_call:
+
+# Publishing on a docs/** push (above) is the standalone default.
+#
+# To ALSO publish docs as part of a release (called from publish-release.yml),
+# add a workflow_call trigger that declares an explicit secrets contract, and
+# have the caller pass the secrets explicitly (do not use `secrets: inherit`):
+#
+#   on:
+#     workflow_call:
+#       secrets:
+#         AWS_ACCOUNT_ID:
+#           required: false
+#         TECHDOCS_AWS_ACCOUNT_ID:
+#           required: false
 
 jobs:
   publish:
     uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
-    secrets: inherit
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      TECHDOCS_AWS_ACCOUNT_ID: ${{ secrets.TECHDOCS_AWS_ACCOUNT_ID }}
     # optional inputs can be specified here to override defaults
     # with:
     #   environment: production


### PR DESCRIPTION
## What

Make the `publish-techdocs` starter template **standalone by default**:

- Drop the `workflow_call` trigger from `workflow-templates/publish-techdocs.yml`. Publishing on a `docs/**` push (plus `workflow_dispatch`) is the natural trigger; techdocs-on-release is an opt-in composition.
- Switch the `publish` job from `secrets: inherit` to passing the two AWS account secrets explicitly (`AWS_ACCOUNT_ID`, `TECHDOCS_AWS_ACCOUNT_ID`, both optional in the reusable).
- Add a commented block showing how to re-add `workflow_call` **with** an explicit `secrets` contract for repos that want the release composition.
- Refresh `docs/workflows/publish-techdocs.md` to match (explicit secrets example + composition note).

## Why

A callable workflow that exposes `workflow_call` without declaring a `secrets:` contract only receives secrets on the call path via `secrets: inherit`. Most installs never call the template as a reusable, so shipping the trigger (and `secrets: inherit`) by default is unused surface and over-broad secret sharing. Standalone-by-default is the safe baseline; the composition is opt-in and explicit.

## Scope

Template + its doc only. This is the source fix; per-repo installed copies are swept separately. The reusable workflow itself is unchanged.

## Test plan

- `actionlint` clean on the template.
- Standalone path: on `docs/**` push the `publish` job calls the reusable; `${{ secrets.AWS_ACCOUNT_ID }}` / `${{ secrets.TECHDOCS_AWS_ACCOUNT_ID }}` resolve from repo/org secrets (empty if unset, and the reusable falls back via `AWS_ACCOUNT_ID || TECHDOCS_AWS_ACCOUNT_ID`).
