### PR TITLE
ci(release): least-privilege caller in release-on-tag source

### DIFF
--- a/.github/workflows/release-auto-on-tag.yml
+++ b/.github/workflows/release-auto-on-tag.yml
@@ -7,8 +7,13 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write # create the GitHub release and push/move tags
     uses: geolonia/.github/.github/workflows/reusable-release-auto-on-tag.yml@c13a68c741150b4151d463e347e77281d0703276 # v1.15.1
-    secrets: inherit
+    # Pass only the secrets the reusable declares, not `inherit`.
+    secrets:
+      WORKFLOWS_CLIENT_ID: ${{ secrets.WORKFLOWS_CLIENT_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
     # Optional settings (uncomment to override defaults):
     # with:
     #   move_major_tag: true

--- a/docs/workflows/release-on-tag.md
+++ b/docs/workflows/release-on-tag.md
@@ -3,16 +3,24 @@
 - Triggers on semver-like tags (`v*.*.*`).
 - Delegates to `reusable-release-auto-on-tag.yml@v1` to create releases and move
   major/minor tags if configured.
-- Inherits calling-repo secrets; optional inputs allow toggling prereleases,
-  generating release notes, or customizing the tag regex.
+- Needs only `contents: write` (to create the release and move tags) and the
+  two `WORKFLOWS_*` GitHub App secrets. Grant the permission on the job and pass
+  those secrets explicitly rather than `secrets: inherit`, so the reusable
+  receives only what it needs.
+- Optional inputs allow toggling prereleases, generating release notes, or
+  customizing the tag regex.
 
 Example minimal usage:
 
 ```yaml
 jobs:
   publish:
+    permissions:
+      contents: write
     uses: geolonia/.github/.github/workflows/reusable-release-auto-on-tag.yml@v1
-    secrets: inherit
+    secrets:
+      WORKFLOWS_CLIENT_ID: ${{ secrets.WORKFLOWS_CLIENT_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
 ```
 
 See the general [Troubleshooting](../workflows.md#troubleshooting) section for

--- a/workflow-templates/release-auto-on-tag.yml
+++ b/workflow-templates/release-auto-on-tag.yml
@@ -7,8 +7,13 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write # create the GitHub release and push/move tags
     uses: geolonia/.github/.github/workflows/reusable-release-auto-on-tag.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
-    secrets: inherit
+    # Pass only the secrets the reusable declares, not `inherit`.
+    secrets:
+      WORKFLOWS_CLIENT_ID: ${{ secrets.WORKFLOWS_CLIENT_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
     # Optional settings (uncomment to override defaults):
     # with:
     #   move_major_tag: true


### PR DESCRIPTION
## What

Make the release-on-tag **caller** least-privilege at the source: the starter template, this repo's own self-release workflow, and the docs example.

- `publish` job gets `permissions: { contents: write }` (was relying on whatever the caller granted).
- Pass `WORKFLOWS_CLIENT_ID` + `WORKFLOWS_APP_PRIVATE_KEY` explicitly instead of `secrets: inherit`.

## Why

`reusable-release-auto-on-tag.yml` declares it needs only `contents: write` and the two `WORKFLOWS_*` GitHub App secrets. `secrets: inherit` shared every repo/org secret with the called workflow, and callers commonly granted broad workflow-level permissions (`id-token`, `models`) the release job never uses. This fixes the pattern where new installs are copied from.

## Scope

Template + `.github`'s own self-caller + docs. Per-repo installed callers are swept separately. `.github-private`'s self-caller is a sibling PR.

## Test plan

- `actionlint` clean.
- The `WORKFLOWS_*` secrets are org-level, so the explicit mapping resolves exactly as `inherit` did.
- Next `vX.Y.Z` tag on this repo exercises the self-caller (it cut v1.17.1 recently).
