### PR TITLE
docs(ci): document why cdk-deploy-monitor needs each permission

### DIFF
--- a/.github/workflows/reusable-cdk-deploy-monitor.yml
+++ b/.github/workflows/reusable-cdk-deploy-monitor.yml
@@ -41,10 +41,12 @@ on:
         description: "OIDC IAM role ARN with cloudformation:DescribeStacks, DescribeStackEvents, DescribeStackResources, CancelUpdateStack, logs:FilterLogEvents, DescribeLogGroups, ecs:ListTasks, DescribeTasks permissions (see CdkDeployMonitor permission bundle)"
         required: true
 
+# All three are used by the monitor (it is not over-granted): a caller that
+# downscopes any of these will silently disable that capability.
 permissions:
-  id-token: write
-  contents: write
-  models: read
+  id-token: write # OIDC: assume the monitor role (CloudFormation / ECS / logs)
+  contents: write # post deploy-status commit comments
+  models: read # GitHub Models: AI analysis of deploy progress
 
 jobs:
   monitor:


### PR DESCRIPTION
Add inline comments to `reusable-cdk-deploy-monitor.yml`'s `permissions` block explaining that `id-token: write` (OIDC), `contents: write` (commit comments), and `models: read` (GitHub Models analysis) are all used, plus a warning that downscoping any of them in a caller silently disables that capability.

Optional follow-up from the geolonia/geolonia-operations#191 audit (the trio nearly got mis-flagged as over-granted; downscoping it in a caller was the geolonia/geolonia-operations#179 regression). No behavior change.