### PR TITLE
feat: add Security Suite workflow (one-stop, ruleset-enforceable)

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -23,16 +23,19 @@ name: Security Suite
 #                 checkout, template injection, excessive permissions,
 #                 credential persistence)
 #
-# A required workflow must reference reusable workflows by full path and
-# ref (not a local ./ path), so the three reusables below are pinned to a
-# released SHA of this repo. Permissions are granted per job (least
-# privilege): the workflow default is read-only, and only the jobs that
-# post PR comments or open tracking issues get write. None of the
-# reusables declare workflow_call secrets, so no `secrets: inherit`.
+# The scanners run in report-mode: summary (they stay quiet and only expose
+# status / count outputs), and the final `report` job posts ONE consolidated
+# comment for the whole suite. So contributors see a single tidy result
+# instead of one comment per scanner.
 #
-# Rollout ramp: zizmor runs warn-only (continue-on-error) so we can observe
-# findings org-wide before blocking. Flip to enforce by removing
-# continue-on-error from the actions-audit job.
+# A required workflow must reference reusable workflows by full path and
+# ref (not a local ./ path), so the reusables below are pinned to a released
+# SHA of this repo. Permissions are granted per job (least privilege): the
+# workflow default is read-only; only the report job posts a comment.
+#
+# Rollout ramp: zizmor runs warn-only (its step is continue-on-error) so we
+# can observe findings org-wide before blocking. Flip to enforce by removing
+# continue-on-error from the Run zizmor step.
 
 on:
   pull_request:
@@ -46,15 +49,16 @@ jobs:
   supply-chain:
     permissions:
       contents: read
-      pull-requests: write # post / update the scan result comment
-      issues: write # open a tracking issue on non-PR triggers
-    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@eb33e7fd9d811e3665a354623edd76294e0bd8bc # v1.17.1
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@d46f419ad3c48566d29cf898634adb66fe16656a # feat/reusable-report-mode (pre-release; bump to the tag once #72 ships)
+    with:
+      report-mode: summary
 
   secret-leak:
     permissions:
       contents: read
-      pull-requests: write # post / update the secret-leak comment
-    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@eb33e7fd9d811e3665a354623edd76294e0bd8bc # v1.17.1
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@d46f419ad3c48566d29cf898634adb66fe16656a # feat/reusable-report-mode (pre-release; bump to the tag once #72 ships)
+    with:
+      report-mode: summary
 
   action-pinning:
     permissions:
@@ -64,17 +68,22 @@ jobs:
   actions-audit:
     name: zizmor (GitHub Actions audit)
     runs-on: ubuntu-latest
-    # Warn-only during rollout. Remove continue-on-error to make zizmor
-    # findings block the PR once the org is clean.
-    continue-on-error: true
     permissions:
       contents: read
+    outputs:
+      # ok when zizmor exits clean, warn otherwise (warn-only rollout).
+      status: ${{ steps.zizmor.outcome == 'success' && 'ok' || 'warn' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Run zizmor
+        id: zizmor
+        # Warn-only during rollout: the step swallows its own failure so the
+        # job (and the run) still passes, while we capture the outcome above.
+        # Remove continue-on-error to make zizmor findings block the PR.
+        continue-on-error: true
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
           # SARIF upload to the security tab needs GitHub Advanced Security,
@@ -89,3 +98,116 @@ jobs:
           # the action SHA, and Dependabot advances it when it bumps the
           # action. Do not request a CLI version newer than the pinned
           # action knows, or it fails with "Unknown version".
+
+  report:
+    name: Security Suite summary
+    needs: [supply-chain, secret-leak, action-pinning, actions-audit]
+    # always(): report even when a check failed. Only meaningful on PRs.
+    if: always() && github.event.pull_request.number != null
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Build and post consolidated comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SUPPLY_STATUS: ${{ needs.supply-chain.outputs.status }}
+          SUPPLY_TOTAL: ${{ needs.supply-chain.outputs.total }}
+          SECRET_STATUS: ${{ needs.secret-leak.outputs.status }}
+          SECRET_TOTAL: ${{ needs.secret-leak.outputs.total }}
+          PIN_RESULT: ${{ needs.action-pinning.result }}
+          ZIZMOR_STATUS: ${{ needs.actions-audit.outputs.status }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- security-suite-v1 -->"
+
+          # Map a status token (ok|warn|fail|error) to a glyph.
+          glyph() {
+            case "$1" in
+              ok) printf '✅' ;;
+              warn) printf '⚠️' ;;
+              fail) printf '❌' ;;
+              *) printf '🟠' ;;
+            esac
+          }
+
+          # pinact exposes no outputs; derive a token from its job result.
+          case "${PIN_RESULT}" in
+            success) PIN_STATUS=ok ;;
+            failure) PIN_STATUS=fail ;;
+            *) PIN_STATUS=error ;;
+          esac
+
+          # Default empty outputs (e.g. a job that errored before setting one)
+          # to "error" so the row is never blank.
+          SUPPLY_STATUS="${SUPPLY_STATUS:-error}"
+          SECRET_STATUS="${SECRET_STATUS:-error}"
+          ZIZMOR_STATUS="${ZIZMOR_STATUS:-error}"
+
+          msg() {
+            local status="$1" ok="$2" some="$3"
+            case "${status}" in
+              ok) echo "${ok}" ;;
+              warn|fail) echo "${some}" ;;
+              *) echo "Scan error (see run)" ;;
+            esac
+          }
+
+          SUPPLY_MSG=$(msg "${SUPPLY_STATUS}" "No exposure matches" "${SUPPLY_TOTAL:-?} match(es)")
+          SECRET_MSG=$(msg "${SECRET_STATUS}" "No secrets in diff" "${SECRET_TOTAL:-?} potential secret(s)")
+          case "${PIN_STATUS}" in
+            ok) PIN_MSG="All actions pinned" ;;
+            fail) PIN_MSG="Unpinned or mismatched (see run)" ;;
+            *) PIN_MSG="Did not complete" ;;
+          esac
+          case "${ZIZMOR_STATUS}" in
+            ok) ZIZMOR_MSG="No findings" ;;
+            warn) ZIZMOR_MSG="Findings (warn-only; see annotations)" ;;
+            *) ZIZMOR_MSG="Did not complete" ;;
+          esac
+
+          # Overall callout: a real failure outranks a warning.
+          ALL="${SUPPLY_STATUS} ${SECRET_STATUS} ${PIN_STATUS} ${ZIZMOR_STATUS}"
+          if printf '%s' "${ALL}" | grep -qw "fail" || printf '%s' "${ALL}" | grep -qw "error"; then
+            CALLOUT="> [!CAUTION]"$'\n'"> A required check did not pass. See the rows above and the workflow run."
+          elif printf '%s' "${ALL}" | grep -qw "warn"; then
+            CALLOUT="> [!WARNING]"$'\n'"> Warnings only. These do not block the PR, but please review them."
+          else
+            CALLOUT="> [!NOTE]"$'\n'"> All security checks passed."
+          fi
+
+          BODY_FILE="suite-comment.md"
+          {
+            echo "${MARKER}"
+            echo ""
+            echo "## 🛡️ Security suite"
+            echo ""
+            echo "| Check | Result |"
+            echo "|:--|:--|"
+            echo "| $(glyph "${SUPPLY_STATUS}") Supply chain · \`bumblebee\` | ${SUPPLY_MSG} |"
+            echo "| $(glyph "${SECRET_STATUS}") Secrets · \`betterleaks\` | ${SECRET_MSG} |"
+            echo "| $(glyph "${PIN_STATUS}") Action pinning · \`pinact\` | ${PIN_MSG} |"
+            echo "| $(glyph "${ZIZMOR_STATUS}") Actions audit · \`zizmor\` | ${ZIZMOR_MSG} |"
+            echo ""
+            echo "${CALLOUT}"
+            echo ""
+            echo "<sub>Updated for \`${HEAD_SHA:0:7}\` · <a href=\"${RUN_URL}\">workflow run</a></sub>"
+          } > "${BODY_FILE}"
+
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --slurp \
+            --jq "[.[].[] | select(.body | startswith(\"${MARKER}\"))] | .[0].id // empty" \
+            2>/dev/null || true)
+          if [ -n "${EXISTING}" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" \
+              -f body="$(cat "${BODY_FILE}")" >/dev/null \
+              && echo "Updated consolidated comment (#${EXISTING})."
+          else
+            gh pr comment "${PR_NUMBER}" --body-file "${BODY_FILE}" \
+              && echo "Posted consolidated comment."
+          fi

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -1,0 +1,91 @@
+name: Security Suite
+
+# Single entry point for Geolonia's per-PR security checks.
+#
+# Designed to run as an organization "required workflow" (Repository
+# Rulesets, "Require workflows to pass before merging"), so every repo gets
+# the same gate with no per-repo workflow file to maintain. Point the org
+# ruleset at:
+#
+#   geolonia/.github/.github/workflows/security-suite.yml@<ref>
+#
+# (geolonia/.github is public, so the ruleset can target public, internal,
+# and private repos.) The file can also be adopted manually by copying it
+# into a repo's .github/workflows/.
+#
+# It fans out to the org reusable scanners plus an inline zizmor job:
+#
+#   * bumblebee   supply-chain package inventory vs. threat-intel catalogs
+#   * betterleaks secret-leak gate (PR diff)
+#   * pinact      GitHub Actions SHA-pinning check
+#   * zizmor      GitHub Actions static analysis (dangerous triggers such
+#                 as pull_request_target / workflow_run with untrusted
+#                 checkout, template injection, excessive permissions,
+#                 credential persistence)
+#
+# A required workflow must reference reusable workflows by full path and
+# ref (not a local ./ path), so the three reusables below are pinned to a
+# released SHA of this repo. Permissions are granted per job (least
+# privilege): the workflow default is read-only, and only the jobs that
+# post PR comments or open tracking issues get write. None of the
+# reusables declare workflow_call secrets, so no `secrets: inherit`.
+#
+# Rollout ramp: zizmor runs warn-only (continue-on-error) so we can observe
+# findings org-wide before blocking. Flip to enforce by removing
+# continue-on-error from the actions-audit job.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  supply-chain:
+    permissions:
+      contents: read
+      pull-requests: write # post / update the scan result comment
+      issues: write # open a tracking issue on non-PR triggers
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@eb33e7fd9d811e3665a354623edd76294e0bd8bc # v1.17.1
+
+  secret-leak:
+    permissions:
+      contents: read
+      pull-requests: write # post / update the secret-leak comment
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@eb33e7fd9d811e3665a354623edd76294e0bd8bc # v1.17.1
+
+  action-pinning:
+    permissions:
+      contents: read
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@eb33e7fd9d811e3665a354623edd76294e0bd8bc # v1.17.1
+
+  actions-audit:
+    name: zizmor (GitHub Actions audit)
+    runs-on: ubuntu-latest
+    # Warn-only during rollout. Remove continue-on-error to make zizmor
+    # findings block the PR once the org is clean.
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # SARIF upload to the security tab needs GitHub Advanced Security,
+          # which is not available on private repos without a license. Use
+          # workflow annotations instead so the job behaves identically on
+          # public, internal, and private repos.
+          advanced-security: false
+          annotations: true
+          # The zizmor CLI version is left at the action default ("latest"),
+          # which the SHA-pinned action resolves to a fixed, digest-pinned
+          # image. So the version is reproducible and supply-chain pinned by
+          # the action SHA, and Dependabot advances it when it bumps the
+          # action. Do not request a CLI version newer than the pinned
+          # action knows, or it fails with "Unknown version".

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -214,6 +214,6 @@ jobs:
               -f body="$(cat "${BODY_FILE}")" >/dev/null \
               && echo "Updated consolidated comment (#${EXISTING})."
           else
-            gh pr comment "${PR_NUMBER}" --body-file "${BODY_FILE}" \
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file "${BODY_FILE}" \
               && echo "Posted consolidated comment."
           fi

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -54,7 +54,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@d46f419ad3c48566d29cf898634adb66fe16656a # feat/reusable-report-mode (pre-release; bump to the tag once #72 ships)
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@1dd4e2d29c56b608703ddab749eb980211cd3661 # v1.18.0
     with:
       report-mode: summary
 
@@ -62,14 +62,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@d46f419ad3c48566d29cf898634adb66fe16656a # feat/reusable-report-mode (pre-release; bump to the tag once #72 ships)
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@1dd4e2d29c56b608703ddab749eb980211cd3661 # v1.18.0
     with:
       report-mode: summary
 
   action-pinning:
     permissions:
       contents: read
-    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@eb33e7fd9d811e3665a354623edd76294e0bd8bc # v1.17.1
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@1dd4e2d29c56b608703ddab749eb980211cd3661 # v1.18.0
 
   actions-audit:
     name: zizmor (GitHub Actions audit)

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -205,9 +205,11 @@ jobs:
             echo "<sub>Updated for \`${HEAD_SHA:0:7}\` · <a href=\"${RUN_URL}\">workflow run</a></sub>"
           } > "${BODY_FILE}"
 
+          # Note: gh's --slurp is incompatible with --jq, so use plain
+          # --paginate (which concatenates pages into one array) + .[].
           EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --paginate --slurp \
-            --jq "[.[].[] | select(.body | startswith(\"${MARKER}\"))] | .[0].id // empty" \
+            --paginate \
+            --jq "[.[] | select(.body | startswith(\"${MARKER}\"))] | .[0].id // empty" \
             2>/dev/null || true)
           if [ -n "${EXISTING}" ]; then
             gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" \

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -42,6 +42,12 @@ on:
     branches:
       - main
 
+# Serialize runs per PR so two overlapping runs cannot both miss the marker
+# comment and each post a "single" consolidated comment.
+concurrency:
+  group: security-suite-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -205,17 +211,31 @@ jobs:
             echo "<sub>Updated for \`${HEAD_SHA:0:7}\` · <a href=\"${RUN_URL}\">workflow run</a></sub>"
           } > "${BODY_FILE}"
 
-          # Note: gh's --slurp is incompatible with --jq, so use plain
-          # --paginate (which concatenates pages into one array) + .[].
+          # Find a prior consolidated comment by its marker. Reads work even
+          # with the read-only token on fork PRs, so this lookup is strict:
+          # an empty result means "no match" (jq's // empty), but a real
+          # API/auth failure exits non-zero and fails the job (set -e) rather
+          # than being masked into a duplicate post. Note: gh's --slurp is
+          # incompatible with --jq, so use plain --paginate + .[].
           EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --paginate \
-            --jq "[.[] | select(.body | startswith(\"${MARKER}\"))] | .[0].id // empty" \
-            2>/dev/null || true)
+            --jq "[.[] | select(.body | startswith(\"${MARKER}\"))] | .[0].id // empty")
+
+          # Posting is best-effort: PRs from forks (and Dependabot) get a
+          # read-only GITHUB_TOKEN regardless of the permissions block, so the
+          # write 403s. Warn instead of failing the whole suite; zizmor
+          # findings still surface as inline annotations.
           if [ -n "${EXISTING}" ]; then
-            gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" \
-              -f body="$(cat "${BODY_FILE}")" >/dev/null \
-              && echo "Updated consolidated comment (#${EXISTING})."
+            if gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" \
+                 -f body="$(cat "${BODY_FILE}")" >/dev/null; then
+              echo "Updated consolidated comment (#${EXISTING})."
+            else
+              echo "::warning::Could not update the consolidated comment (read-only token on a fork PR?)."
+            fi
           else
-            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file "${BODY_FILE}" \
-              && echo "Posted consolidated comment."
+            if gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file "${BODY_FILE}" >/dev/null; then
+              echo "Posted consolidated comment."
+            else
+              echo "::warning::Could not post the consolidated comment (read-only token on a fork PR?)."
+            fi
           fi

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -47,8 +47,13 @@ permissions:
 
 jobs:
   supply-chain:
+    # A called reusable can only downgrade the caller's token, never
+    # elevate it, so these must grant at least what the reusable declares
+    # at its workflow level (even though summary mode does not post).
     permissions:
       contents: read
+      pull-requests: write
+      issues: write
     uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@d46f419ad3c48566d29cf898634adb66fe16656a # feat/reusable-report-mode (pre-release; bump to the tag once #72 ships)
     with:
       report-mode: summary
@@ -56,6 +61,7 @@ jobs:
   secret-leak:
     permissions:
       contents: read
+      pull-requests: write
     uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@d46f419ad3c48566d29cf898634adb66fe16656a # feat/reusable-report-mode (pre-release; bump to the tag once #72 ships)
     with:
       report-mode: summary


### PR DESCRIPTION
## What

Adds `security-suite.yml`: a single entry point for Geolonia's per-PR security checks, designed to be enforced org-wide as a **required workflow** (Repository Rulesets) so every repo gets the same gate with **no per-repo workflow file to maintain**.

It fans out to the existing org reusable scanners plus a new zizmor job:

| Job | Tool | Catches |
|---|---|---|
| `supply-chain` | bumblebee | compromised packages vs. threat-intel catalogs |
| `secret-leak` | betterleaks | secrets in the PR diff |
| `action-pinning` | pinact | unpinned / mismatched GitHub Actions |
| `actions-audit` | **zizmor** | `pull_request_target` / `workflow_run` with untrusted checkout, template injection, excessive permissions, credential persistence |

## Why

We have several good reusable security workflows, but asking every repo to wire up each one leads to partial adoption (see geolonia-operations#195). Consolidating into one suite + enforcing via an org ruleset makes security the default with zero developer setup, and lets us add a scanner once centrally and have every repo pick it up.

## Required follow-up (org settings, manual)

This PR only adds the workflow. To enforce it, create an **organization ruleset**:

- Org Settings -> Rules -> Rulesets -> New ruleset -> New branch ruleset
- Target: all repos (or by custom property), branch `main`
- Rule: **Require workflows to pass before merging** -> add workflow
  `geolonia/.github` / `.github/workflows/security-suite.yml` @ a pinned ref (tag)
- Start in **Evaluate** mode to observe, then switch to **Active**

`geolonia/.github` is public, so the workflow can run on public, internal, and private repos. Org rulesets incl. require-workflows are GA on the Team plan (2025-06).

## Design notes

- **Required-workflow constraint:** the three reusables are referenced by full path + pinned SHA (`@eb33e7f # v1.17.1`), because a required workflow may not use local `./` reusable paths.
- **Least privilege:** workflow default is `contents: read`; only the jobs that comment / open issues get write, scoped per job. (zizmor confirms: no findings on this file.)
- **Private-repo portable:** zizmor uses `advanced-security: false` + `annotations: true` so it does not depend on GHAS / SARIF upload, which is unavailable on private repos without a license.
- **Rollout ramp:** zizmor is `continue-on-error: true` (warn-only). Flip to enforce by removing that line once the org is clean.
- **No secrets:** none of the reusables declare `workflow_call` secrets, so no `secrets: inherit`.

## After the ruleset is live (separate PR)

Remove the now-redundant per-repo caller workflows (bumblebee / betterleaks / pinact) so scanners do not double-run.

Part of geolonia-operations#196. Umbrella: geolonia-operations#195.

## Validation

- `actionlint` clean
- `zizmor` self-audit: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added a new “Security Suite” GitHub Actions workflow for pull requests targeting the main branch.
  * Runs multiple automated scanners (supply-chain, secret leakage, and Actions security checks) with least-privilege settings.
  * Produces a single consolidated Markdown summary and updates/creates one PR comment via a fixed marker.
  * Reports findings as warn-only during the rollout ramp (non-blocking), while consolidating statuses into an overall callout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->