### PR TITLE
feat: add summary report-mode + outputs to scanner reusables

### DIFF
--- a/.github/workflows/reusable-bumblebee-scan.yml
+++ b/.github/workflows/reusable-bumblebee-scan.yml
@@ -42,6 +42,18 @@ on:
         type: string
         required: false
         default: "project"
+      report-mode:
+        description: "comment (default): post or update the PR comment and open tracking issues. summary: stay quiet and only expose the outputs below, for an aggregator such as the Security Suite."
+        type: string
+        required: false
+        default: "comment"
+    outputs:
+      status:
+        description: "Result of the scan: ok, warn, fail, or error."
+        value: ${{ jobs.scan.outputs.status }}
+      total:
+        description: "Number of exposure matches found."
+        value: ${{ jobs.scan.outputs.total }}
 
 permissions:
   contents: read        # checkout the repository
@@ -53,6 +65,9 @@ jobs:
     name: bumblebee (${{ inputs.profile }} scan)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      status: ${{ steps.status.outputs.status }}
+      total: ${{ steps.findings.outputs.total }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -109,6 +124,25 @@ jobs:
           fi
           TOTAL=$(grep -c '"record_type":"finding"' bumblebee-findings.ndjson || true)
           echo "total=${TOTAL:-0}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute status
+        id: status
+        if: always()
+        env:
+          SCAN_FAILED: ${{ steps.findings.outputs.scan_failed }}
+          TOTAL: ${{ steps.findings.outputs.total }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+        run: |
+          if [ "${SCAN_FAILED}" = "true" ]; then
+            STATUS="error"
+          elif [ "${TOTAL:-0}" = "0" ]; then
+            STATUS="ok"
+          elif [ "${FAIL_ON_FINDINGS}" = "true" ]; then
+            STATUS="fail"
+          else
+            STATUS="warn"
+          fi
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
 
       - name: Emit inline annotations
         if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0'
@@ -179,7 +213,7 @@ jobs:
       - name: Post / update PR comment
         # GITHUB_TOKEN is read-only on fork PRs / Dependabot PRs. Degrade
         # gracefully — annotations + artifact still carry the report.
-        if: always() && github.event.pull_request.number != null
+        if: always() && inputs.report-mode != 'summary' && github.event.pull_request.number != null
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -211,7 +245,7 @@ jobs:
         # PR to comment on. Open one tracking issue per repo (label
         # `bumblebee-finding`), updating it idempotently via a marker
         # so re-runs don't spam.
-        if: always() && github.event.pull_request.number == null && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0'
+        if: always() && inputs.report-mode != 'summary' && github.event.pull_request.number == null && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -44,6 +44,18 @@ on:
         type: boolean
         required: false
         default: false
+      report-mode:
+        description: "comment (default): post or update the PR comment. summary: stay quiet and only expose the outputs below, for an aggregator such as the Security Suite."
+        type: string
+        required: false
+        default: "comment"
+    outputs:
+      status:
+        description: "Result of the scan: ok, warn, fail, or error."
+        value: ${{ jobs.scan.outputs.status }}
+      total:
+        description: "Number of potential secrets found in the PR diff."
+        value: ${{ jobs.scan.outputs.total }}
 
 permissions:
   contents: read
@@ -54,6 +66,9 @@ jobs:
     name: betterleaks (PR diff)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      status: ${{ steps.status.outputs.status }}
+      total: ${{ steps.findings.outputs.total }}
     steps:
       - name: Checkout (full history)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -160,6 +175,25 @@ jobs:
           fi
           echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
 
+      - name: Compute status
+        id: status
+        if: always()
+        env:
+          SCAN_FAILED: ${{ steps.findings.outputs.scan_failed }}
+          TOTAL: ${{ steps.findings.outputs.total }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+        run: |
+          if [ "${SCAN_FAILED}" = "true" ]; then
+            STATUS="error"
+          elif [ "${TOTAL:-0}" = "0" ]; then
+            STATUS="ok"
+          elif [ "${FAIL_ON_FINDINGS}" = "true" ]; then
+            STATUS="fail"
+          else
+            STATUS="warn"
+          fi
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+
       - name: Emit inline annotations
         if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0'
         run: |
@@ -242,7 +276,7 @@ jobs:
         # let the inline annotations + artifact carry the report. The
         # job's pass/fail status is decided by the dedicated fail step
         # below, not by whether we managed to post a comment.
-        if: always() && github.event.pull_request.number != null
+        if: always() && inputs.report-mode != 'summary' && github.event.pull_request.number != null
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What

Adds a `report-mode` input plus `workflow_call` outputs to the two scanner reusables that post PR comments (`reusable-bumblebee-scan.yml`, `reusable-secret-leak-check.yml`):

- **`report-mode`** (string, default `"comment"`) — `comment` keeps today's behavior exactly (post / update the PR comment, open tracking issues). `summary` makes the reusable stay quiet and only expose its results.
- **Outputs** `status` (`ok` / `warn` / `fail` / `error`) and `total` (finding count).

## Why

Today each scanner posts its own bare PR comment (and the text shows literal `OK` / `X` instead of a status glyph). The goal is **one** consolidated "Security Suite" comment with a status table. This PR is the prerequisite: it lets the suite call each scanner in `summary` mode and aggregate the outputs into a single comment.

`pinact` posts no comment (it is a pure gate), so it needs no change. The suite reads its pass/fail from the job result.

## Backward compatible

Default `report-mode: comment` means every existing caller behaves identically. Only the Security Suite (geolonia-operations#196) will pass `report-mode: summary`.

## Next (separate PR, after this releases)

Because a required workflow must reference reusables by a released ref, the suite work lands after this is tagged: bump `security-suite.yml` to the new release and add a `report` job that posts the consolidated comment from these outputs.

Part of geolonia-operations#196. Umbrella: geolonia-operations#195.

## Validation

- `actionlint` clean on both files.
