### PR TITLE
feat: extract reusable-security-suite.yml (single source for the suite)

### DIFF
--- a/.github/workflows/reusable-security-suite.yml
+++ b/.github/workflows/reusable-security-suite.yml
@@ -1,0 +1,227 @@
+name: "[REUSABLE] Security Suite"
+
+# Geolonia's consolidated per-PR security suite, as a single reusable.
+#
+# Two thin callers use it, so the suite logic lives in exactly one place:
+#
+#   * .github/workflows/security-suite.yml  the org "required workflow"
+#     (Repository Rulesets) that runs on every targeted repo with no file
+#     in that repo.
+#   * workflow-templates/security-suite.yml  the "New workflow" picker
+#     entry, for repos that opt in manually instead of via the ruleset.
+#
+# It fans out to the org reusable scanners plus an inline zizmor job:
+#
+#   * bumblebee   supply-chain package inventory vs. threat-intel catalogs
+#   * betterleaks secret-leak gate (PR diff)
+#   * pinact      GitHub Actions SHA-pinning check
+#   * zizmor      GitHub Actions static analysis (dangerous triggers such
+#                 as pull_request_target / workflow_run with untrusted
+#                 checkout, template injection, excessive permissions,
+#                 credential persistence)
+#
+# The scanners run in report-mode: summary (they stay quiet and only expose
+# status / count outputs), and the final `report` job posts ONE consolidated
+# comment for the whole suite. So contributors see a single tidy result
+# instead of one comment per scanner.
+#
+# Permissions note: a called reusable can only downgrade the caller's token,
+# never elevate it. The jobs below need pull-requests: write (to comment) and
+# issues: write (bumblebee tracking issue on non-PR triggers), so the CALLER
+# job's `uses:` must grant that union; each job here narrows to what it needs.
+#
+# Rollout ramp: zizmor runs warn-only (its step is continue-on-error) so we
+# can observe findings org-wide before blocking. Flip to enforce by removing
+# continue-on-error from the Run zizmor step.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  supply-chain:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@1dd4e2d29c56b608703ddab749eb980211cd3661 # v1.18.0
+    with:
+      report-mode: summary
+
+  secret-leak:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@1dd4e2d29c56b608703ddab749eb980211cd3661 # v1.18.0
+    with:
+      report-mode: summary
+
+  action-pinning:
+    permissions:
+      contents: read
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@1dd4e2d29c56b608703ddab749eb980211cd3661 # v1.18.0
+
+  actions-audit:
+    name: zizmor (GitHub Actions audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      # ok when zizmor exits clean, warn otherwise (warn-only rollout).
+      status: ${{ steps.zizmor.outcome == 'success' && 'ok' || 'warn' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        id: zizmor
+        # Warn-only during rollout: the step swallows its own failure so the
+        # job (and the run) still passes, while we capture the outcome above.
+        # Remove continue-on-error to make zizmor findings block the PR.
+        continue-on-error: true
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # SARIF upload to the security tab needs GitHub Advanced Security,
+          # which is not available on private repos without a license. Use
+          # workflow annotations instead so the job behaves identically on
+          # public, internal, and private repos.
+          advanced-security: false
+          annotations: true
+          # The zizmor CLI version is left at the action default ("latest"),
+          # which the SHA-pinned action resolves to a fixed, digest-pinned
+          # image. So the version is reproducible and supply-chain pinned by
+          # the action SHA, and Dependabot advances it when it bumps the
+          # action. Do not request a CLI version newer than the pinned
+          # action knows, or it fails with "Unknown version".
+
+  report:
+    name: Security Suite summary
+    needs: [supply-chain, secret-leak, action-pinning, actions-audit]
+    # always(): report even when a check failed. Only meaningful on PRs.
+    if: always() && github.event.pull_request.number != null
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Build and post consolidated comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SUPPLY_STATUS: ${{ needs.supply-chain.outputs.status }}
+          SUPPLY_TOTAL: ${{ needs.supply-chain.outputs.total }}
+          SECRET_STATUS: ${{ needs.secret-leak.outputs.status }}
+          SECRET_TOTAL: ${{ needs.secret-leak.outputs.total }}
+          PIN_RESULT: ${{ needs.action-pinning.result }}
+          ZIZMOR_STATUS: ${{ needs.actions-audit.outputs.status }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- security-suite-v1 -->"
+
+          # Map a status token (ok|warn|fail|error) to a glyph.
+          glyph() {
+            case "$1" in
+              ok) printf '✅' ;;
+              warn) printf '⚠️' ;;
+              fail) printf '❌' ;;
+              *) printf '🟠' ;;
+            esac
+          }
+
+          # pinact exposes no outputs; derive a token from its job result.
+          case "${PIN_RESULT}" in
+            success) PIN_STATUS=ok ;;
+            failure) PIN_STATUS=fail ;;
+            *) PIN_STATUS=error ;;
+          esac
+
+          # Default empty outputs (e.g. a job that errored before setting one)
+          # to "error" so the row is never blank.
+          SUPPLY_STATUS="${SUPPLY_STATUS:-error}"
+          SECRET_STATUS="${SECRET_STATUS:-error}"
+          ZIZMOR_STATUS="${ZIZMOR_STATUS:-error}"
+
+          msg() {
+            local status="$1" ok="$2" some="$3"
+            case "${status}" in
+              ok) echo "${ok}" ;;
+              warn|fail) echo "${some}" ;;
+              *) echo "Scan error (see run)" ;;
+            esac
+          }
+
+          SUPPLY_MSG=$(msg "${SUPPLY_STATUS}" "No exposure matches" "${SUPPLY_TOTAL:-?} match(es)")
+          SECRET_MSG=$(msg "${SECRET_STATUS}" "No secrets in diff" "${SECRET_TOTAL:-?} potential secret(s)")
+          case "${PIN_STATUS}" in
+            ok) PIN_MSG="All actions pinned" ;;
+            fail) PIN_MSG="Unpinned or mismatched (see run)" ;;
+            *) PIN_MSG="Did not complete" ;;
+          esac
+          case "${ZIZMOR_STATUS}" in
+            ok) ZIZMOR_MSG="No findings" ;;
+            warn) ZIZMOR_MSG="Findings (warn-only; see annotations)" ;;
+            *) ZIZMOR_MSG="Did not complete" ;;
+          esac
+
+          # Overall callout: a real failure outranks a warning.
+          ALL="${SUPPLY_STATUS} ${SECRET_STATUS} ${PIN_STATUS} ${ZIZMOR_STATUS}"
+          if printf '%s' "${ALL}" | grep -qw "fail" || printf '%s' "${ALL}" | grep -qw "error"; then
+            CALLOUT="> [!CAUTION]"$'\n'"> A required check did not pass. See the rows above and the workflow run."
+          elif printf '%s' "${ALL}" | grep -qw "warn"; then
+            CALLOUT="> [!WARNING]"$'\n'"> Warnings only. These do not block the PR, but please review them."
+          else
+            CALLOUT="> [!NOTE]"$'\n'"> All security checks passed."
+          fi
+
+          BODY_FILE="suite-comment.md"
+          {
+            echo "${MARKER}"
+            echo ""
+            echo "## 🛡️ Security suite"
+            echo ""
+            echo "| Check | Result |"
+            echo "|:--|:--|"
+            echo "| $(glyph "${SUPPLY_STATUS}") Supply chain · \`bumblebee\` | ${SUPPLY_MSG} |"
+            echo "| $(glyph "${SECRET_STATUS}") Secrets · \`betterleaks\` | ${SECRET_MSG} |"
+            echo "| $(glyph "${PIN_STATUS}") Action pinning · \`pinact\` | ${PIN_MSG} |"
+            echo "| $(glyph "${ZIZMOR_STATUS}") Actions audit · \`zizmor\` | ${ZIZMOR_MSG} |"
+            echo ""
+            echo "${CALLOUT}"
+            echo ""
+            echo "<sub>Updated for \`${HEAD_SHA:0:7}\` · <a href=\"${RUN_URL}\">workflow run</a></sub>"
+          } > "${BODY_FILE}"
+
+          # Find a prior consolidated comment by its marker. Reads work even
+          # with the read-only token on fork PRs, so this lookup is strict:
+          # an empty result means "no match" (jq's // empty), but a real
+          # API/auth failure exits non-zero and fails the job (set -e) rather
+          # than being masked into a duplicate post. Note: gh's --slurp is
+          # incompatible with --jq, so use plain --paginate + .[].
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq "[.[] | select(.body | startswith(\"${MARKER}\"))] | .[0].id // empty")
+
+          # Posting is best-effort: PRs from forks (and Dependabot) get a
+          # read-only GITHUB_TOKEN regardless of the permissions block, so the
+          # write 403s. Warn instead of failing the whole suite; zizmor
+          # findings still surface as inline annotations.
+          if [ -n "${EXISTING}" ]; then
+            if gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" \
+                 -f body="$(cat "${BODY_FILE}")" >/dev/null; then
+              echo "Updated consolidated comment (#${EXISTING})."
+            else
+              echo "::warning::Could not update the consolidated comment (read-only token on a fork PR?)."
+            fi
+          else
+            if gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file "${BODY_FILE}" >/dev/null; then
+              echo "Posted consolidated comment."
+            else
+              echo "::warning::Could not post the consolidated comment (read-only token on a fork PR?)."
+            fi
+          fi


### PR DESCRIPTION
## What

Extracts the consolidated Security Suite into a single reusable workflow, `reusable-security-suite.yml` (workflow_call): the three org scanners (bumblebee + betterleaks in `report-mode: summary`, pinact) + the inline zizmor job + the aggregated single-comment `report` job.

## Why

Right now the suite logic lives in `.github/workflows/security-suite.yml` (the ruleset source). To also offer it in the org "New workflow" picker without copy-pasting ~230 lines (which would drift), the logic needs to live in one place. After this ships:

- `security-suite.yml` (ruleset source) becomes a thin one-line caller.
- `workflow-templates/security-suite.yml` (picker entry) is the same thin caller.
- The three individual scanner templates (bumblebee / secret-leak / pinact) get retired from the picker in favor of this one entry.

That follow-up is **PR-2**, which can only land once this reusable is released (a required/template workflow must reference reusables by a released tag, not a branch).

## Notes

- Logic is unchanged from the merged `security-suite.yml` (same jobs, same report job). Only the trigger changes (`on: workflow_call`) and the per-PR `concurrency` group moves to the thin callers.
- Permissions: a called reusable can only downgrade the caller's token, so the thin caller's `uses:` job must grant the union (`contents: read`, `pull-requests: write`, `issues: write`); each job here narrows to what it needs.

Part of geolonia-operations#196.

## Validation

- `actionlint` clean
- `zizmor` self-audit: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consolidated security-check workflow that runs multiple security scans together and posts a single summary comment on pull requests.
  * Security results are now shown with clear pass/warn/fail indicators and a helpful overall status message.

* **Bug Fixes**
  * Improved pull request reporting so security summaries update an existing comment when possible.
  * Made comment posting best-effort, so limited permissions on some PRs won’t block the checks from running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->