### PR TITLE
fix: bump suite to reusable-security-suite@v1.22.0 (activate warn-only pinact + config fallback)

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -40,4 +40,4 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@63e21d7f7f58f814bf2cc6add0b874a5f6a0d6d6 # v1.20.0
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@d32aef43567e5b8d55e302a8988125f66ec92786 # v1.22.0


### PR DESCRIPTION
## What

Bumps the `security-suite.yml` thin caller from `reusable-security-suite@v1.20.0` to **`@v1.22.0`**.

## Why (latent bug)

The ruleset (`security-suite.yml@v1`) was running a stale chain:

```
security-suite.yml@v1 → reusable-security-suite@v1.20.0 (pre-PR-Y)
                      → reusable-pinact-check@v1.18.0   (gating, no config fallback)
```

So #75 (centralized `.pinact.yml` fallback) and #76 (warn-only pinact) were **inert** — the ruleset kept running the old gating pinact with no fallback. This bump repoints to `@v1.22.0`, which resolves to `reusable-pinact-check@v1.21.0` with `fail-on-findings: false`, so the suite finally runs pinact warn-only + centralized-config.

## Note: internal pin maintenance

This is an internal same-repo reusable pin. Dependabot's github-actions ecosystem generally does **not** bump same-repo reusable-workflow refs, which is why it went stale. Options to avoid recurrence: keep bumping it manually when `reusable-security-suite` changes, or track it another way. Flagging for awareness.

Part of geolonia-operations#196.

## Validation

- `actionlint` clean; confirmed the resolved chain reaches `pinact@v1.21.0` + `fail-on-findings: false`.
- This PR's own CI runs the new chain on `.github` (first live exercise of warn-only pinact + fallback).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s security workflow to use a newer approved version of the reusable security suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->