### PR TITLE
feat: centralized zizmor ignore-list + severity-aware suite summary

### DIFF
--- a/.github/workflows/reusable-security-suite.yml
+++ b/.github/workflows/reusable-security-suite.yml
@@ -129,7 +129,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # post / update the consolidated comment
+      checks: read # read the zizmor check-run annotations to tally severity
     steps:
       - name: Build and post consolidated comment
         env:
@@ -190,8 +191,8 @@ jobs:
           ZIZMOR_ERRORS=0
           ZIZMOR_WARNINGS=0
           if [ "${ZIZMOR_STATUS}" != "ok" ]; then
-            CRID=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
-              --jq "[.check_runs[] | select(.name | test(\"zizmor\"; \"i\")) | select(.details_url | test(\"/runs/${RUN_ID}/\"))] | .[0].id // empty" 2>/dev/null || true)
+            CRID=$(gh api --paginate --slurp "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null \
+              | jq -r "[.[].check_runs[] | select(.name | test(\"zizmor\"; \"i\")) | select(.details_url | test(\"/runs/${RUN_ID}/\"))] | .[0].id // empty" 2>/dev/null || true)
             if [ -n "${CRID}" ]; then
               # --paginate --slurp collects every page into one array of
               # page-arrays (flatten with .[][]); a check run can have more

--- a/.github/workflows/reusable-security-suite.yml
+++ b/.github/workflows/reusable-security-suite.yml
@@ -81,6 +81,25 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - name: Ensure zizmor config
+        # Centralized ignore-list: when the repo ships no zizmor.yml, fetch
+        # the canonical one from geolonia/.github@main so org-wide accepted
+        # findings are suppressed in one place. zizmor auto-discovers a
+        # zizmor.yml at the repo root. A repo can override with its own.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CONFIG_REPO: geolonia/.github
+          CONFIG_REF: main
+        run: |
+          if [ -f zizmor.yml ] || [ -f zizmor.yaml ] || [ -f .github/zizmor.yml ] || [ -f .github/zizmor.yaml ]; then
+            echo "Using this repo's own zizmor config."
+          elif gh api "repos/${CONFIG_REPO}/contents/zizmor.yml?ref=${CONFIG_REF}" \
+                 -H "Accept: application/vnd.github.raw" > zizmor.yml 2>/dev/null && [ -s zizmor.yml ]; then
+            echo "::notice::No zizmor.yml in this repo; using the centralized ignore-list from ${CONFIG_REPO}@${CONFIG_REF}."
+          else
+            rm -f zizmor.yml
+            echo "No centralized zizmor config available; zizmor uses its defaults."
+          fi
       - name: Run zizmor
         id: zizmor
         # Warn-only during rollout: the step swallows its own failure so the
@@ -118,6 +137,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           SUPPLY_STATUS: ${{ needs.supply-chain.outputs.status }}
           SUPPLY_TOTAL: ${{ needs.supply-chain.outputs.total }}
@@ -163,17 +183,44 @@ jobs:
             fail) PIN_MSG="Unpinned or mismatched (see run)" ;;
             *) PIN_MSG="Did not complete" ;;
           esac
-          case "${ZIZMOR_STATUS}" in
-            ok) ZIZMOR_MSG="No findings" ;;
-            warn) ZIZMOR_MSG="Findings (warn-only; see annotations)" ;;
-            *) ZIZMOR_MSG="Did not complete" ;;
-          esac
 
-          # Overall callout: a real failure outranks a warning.
-          ALL="${SUPPLY_STATUS} ${SECRET_STATUS} ${PIN_STATUS} ${ZIZMOR_STATUS}"
-          if printf '%s' "${ALL}" | grep -qw "fail" || printf '%s' "${ALL}" | grep -qw "error"; then
+          # zizmor is warn-only, but distinguish error-severity from warning-
+          # severity findings so the summary does not understate errors.
+          # Count this run's zizmor annotations by level from its check run.
+          ZIZMOR_ERRORS=0
+          ZIZMOR_WARNINGS=0
+          if [ "${ZIZMOR_STATUS}" != "ok" ]; then
+            CRID=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+              --jq "[.check_runs[] | select(.name | test(\"zizmor\"; \"i\")) | select(.details_url | test(\"/runs/${RUN_ID}/\"))] | .[0].id // empty" 2>/dev/null || true)
+            if [ -n "${CRID}" ]; then
+              gh api "repos/${REPO}/check-runs/${CRID}/annotations?per_page=100" > ann.json 2>/dev/null || echo '[]' > ann.json
+              REAL='[.[] | select((.message | contains("Process completed with exit code")) | not)]'
+              ZIZMOR_ERRORS=$(jq "${REAL} | map(select(.annotation_level == \"failure\")) | length" ann.json 2>/dev/null || echo 0)
+              ZIZMOR_WARNINGS=$(jq "${REAL} | map(select(.annotation_level == \"warning\")) | length" ann.json 2>/dev/null || echo 0)
+            fi
+          fi
+
+          if [ "${ZIZMOR_STATUS}" = "ok" ]; then
+            ZIZMOR_GLYPH="✅"; ZIZMOR_MSG="No findings"; ZIZMOR_SEV="ok"
+          elif [ "${ZIZMOR_ERRORS:-0}" -gt 0 ]; then
+            ZIZMOR_GLYPH="❗"; ZIZMOR_SEV="error"
+            ZIZMOR_MSG="${ZIZMOR_ERRORS} error(s), ${ZIZMOR_WARNINGS} warning(s) (warn-only; see annotations)"
+          elif [ "${ZIZMOR_WARNINGS:-0}" -gt 0 ]; then
+            ZIZMOR_GLYPH="⚠️"; ZIZMOR_SEV="warn"
+            ZIZMOR_MSG="${ZIZMOR_WARNINGS} warning(s) (warn-only; see annotations)"
+          else
+            ZIZMOR_GLYPH="⚠️"; ZIZMOR_SEV="warn"; ZIZMOR_MSG="Findings (warn-only; see annotations)"
+          fi
+
+          # Overall callout. Hard gates (bumblebee/betterleaks/pinact) can
+          # block; zizmor is warn-only (never blocks) but error-severity
+          # findings still escalate the callout so they are not hidden.
+          GATES="${SUPPLY_STATUS} ${SECRET_STATUS} ${PIN_STATUS}"
+          if printf '%s' "${GATES}" | grep -qwE "fail|error"; then
             CALLOUT="> [!CAUTION]"$'\n'"> A required check did not pass. See the rows above and the workflow run."
-          elif printf '%s' "${ALL}" | grep -qw "warn"; then
+          elif [ "${ZIZMOR_SEV}" = "error" ]; then
+            CALLOUT="> [!CAUTION]"$'\n'"> zizmor found error-severity issues. They are warn-only (they do not block this PR), but please address them."
+          elif printf '%s' "${GATES}" | grep -qw "warn" || [ "${ZIZMOR_SEV}" = "warn" ]; then
             CALLOUT="> [!WARNING]"$'\n'"> Warnings only. These do not block the PR, but please review them."
           else
             CALLOUT="> [!NOTE]"$'\n'"> All security checks passed."
@@ -190,7 +237,7 @@ jobs:
             echo "| $(glyph "${SUPPLY_STATUS}") Supply chain · \`bumblebee\` | ${SUPPLY_MSG} |"
             echo "| $(glyph "${SECRET_STATUS}") Secrets · \`betterleaks\` | ${SECRET_MSG} |"
             echo "| $(glyph "${PIN_STATUS}") Action pinning · \`pinact\` | ${PIN_MSG} |"
-            echo "| $(glyph "${ZIZMOR_STATUS}") Actions audit · \`zizmor\` | ${ZIZMOR_MSG} |"
+            echo "| ${ZIZMOR_GLYPH} Actions audit · \`zizmor\` | ${ZIZMOR_MSG} |"
             echo ""
             echo "${CALLOUT}"
             echo ""

--- a/.github/workflows/reusable-security-suite.yml
+++ b/.github/workflows/reusable-security-suite.yml
@@ -193,8 +193,12 @@ jobs:
             CRID=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
               --jq "[.check_runs[] | select(.name | test(\"zizmor\"; \"i\")) | select(.details_url | test(\"/runs/${RUN_ID}/\"))] | .[0].id // empty" 2>/dev/null || true)
             if [ -n "${CRID}" ]; then
-              gh api "repos/${REPO}/check-runs/${CRID}/annotations?per_page=100" > ann.json 2>/dev/null || echo '[]' > ann.json
-              REAL='[.[] | select((.message | contains("Process completed with exit code")) | not)]'
+              # --paginate --slurp collects every page into one array of
+              # page-arrays (flatten with .[][]); a check run can have more
+              # than one page of annotations. --slurp is safe here because we
+              # write to a file and run jq separately (not with --jq).
+              gh api --paginate --slurp "repos/${REPO}/check-runs/${CRID}/annotations?per_page=100" > ann.json 2>/dev/null || echo '[]' > ann.json
+              REAL='[.[][] | select((.message | contains("Process completed with exit code")) | not)]'
               ZIZMOR_ERRORS=$(jq "${REAL} | map(select(.annotation_level == \"failure\")) | length" ann.json 2>/dev/null || echo 0)
               ZIZMOR_WARNINGS=$(jq "${REAL} | map(select(.annotation_level == \"warning\")) | length" ann.json 2>/dev/null || echo 0)
             fi

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -40,4 +40,5 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      checks: read # report job reads zizmor check-run annotations
     uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@d32aef43567e5b8d55e302a8988125f66ec92786 # v1.22.0

--- a/workflow-templates/security-suite.yml
+++ b/workflow-templates/security-suite.yml
@@ -33,4 +33,5 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      checks: read # report job reads zizmor check-run annotations
     uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@63e21d7f7f58f814bf2cc6add0b874a5f6a0d6d6 # v1.20.0

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,22 @@
+# Centralized zizmor ignore-list (allow-list) for the Geolonia org.
+#
+# The Security Suite fetches this file when a repo has no zizmor.yml of its
+# own, so org-wide accepted findings are suppressed in ONE place (the same
+# pattern as the canonical .pinact.yml). A repo can override by committing
+# its own zizmor.yml.
+#
+# IMPORTANT: zizmor's `ignore` entries are matched by exact workflow
+# filename (optionally `name.yml:line` or `name.yml:line:col`); globs like
+# `*.yml` are NOT supported. So an entry suppresses a rule only in files
+# with that basename. That is ideal for the org-standard workflows that are
+# copied into many repos (route-issue.yml, publish-techdocs.yml, ...), but
+# it cannot disable a rule everywhere. Prefer fixing over ignoring; keep
+# every entry below justified.
+#
+# Example (uncomment + justify when the org accepts a finding):
+#
+# rules:
+#   template-injection:
+#     ignore:
+#       - route-issue.yml   # title/body only reaches a trusted internal step
+rules: {}


### PR DESCRIPTION
## What

Two refinements to the Security Suite:

1. **Centralized zizmor ignore-list.** Adds a canonical `zizmor.yml` to `geolonia/.github`. The suite's zizmor job fetches it (with a `::notice::`) when the target repo ships no `zizmor.yml` of its own, so org-wide accepted findings are suppressed in one place. A repo can override by committing its own. Mirrors the `.pinact.yml` fallback.
2. **Severity-aware summary.** The report job now reads the run's actual zizmor annotations and renders the row by severity:
   - clean -> `✅ No findings`
   - warnings only -> `⚠️ N warning(s)`
   - **error-severity present -> `❗ E error(s), W warning(s)`** and the callout escalates to `[!CAUTION]` (still warn-only, does not block)

So the summary no longer shows a soft "warning" when there are error-severity findings.

## Note on the ignore-list

zizmor's `ignore` entries match by **exact workflow filename** (no globs). So the centralized list suppresses accepted findings in the org-standard shared workflows (`route-issue.yml`, `publish-techdocs.yml`, ...) that are copied across repos. Truly-global rule disabling isn't supported by zizmor; repo-specific findings get fixed or a repo-local `zizmor.yml`. Starts empty (`rules: {}`); we populate it as we triage the ~125 findings.

Part of geolonia-operations#196 / #200.

## Validation

- `actionlint` clean; `zizmor` self-audit: no findings; jq counting verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security suite now automatically uses a repo-local `zizmor.yml` when present; otherwise it fetches a shared org-wide fallback.
  * Audit reporting now derives alert details from the specific Zizmor check run for the current commit/run, improving consistency in the consolidated report.

* **Bug Fixes**
  * Updated callout/severity logic so hard-gate issues still dominate, while Zizmor findings at failure level produce clearer caution messaging without changing blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->