### PR TITLE
chore: bump suite callers to reusable-security-suite@v1.24.0

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -41,4 +41,4 @@ jobs:
       pull-requests: write
       issues: write
       checks: read # report job reads zizmor check-run annotations
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@d32aef43567e5b8d55e302a8988125f66ec92786 # v1.22.0
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@39820bb4238be1f3160e8d705c7c2942013711cb # v1.24.0

--- a/workflow-templates/security-suite.yml
+++ b/workflow-templates/security-suite.yml
@@ -34,4 +34,4 @@ jobs:
       pull-requests: write
       issues: write
       checks: read # report job reads zizmor check-run annotations
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@63e21d7f7f58f814bf2cc6add0b874a5f6a0d6d6 # v1.20.0
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@39820bb4238be1f3160e8d705c7c2942013711cb # v1.24.0


### PR DESCRIPTION
Activates #81 (centralized zizmor ignore-list, severity-aware summary, report-job checks:read) through the ruleset by pointing the thin callers at the released reusable. Caller `checks: read` grant already landed in #81. Part of geolonia-operations#196.