### PR TITLE
chore: bump suite callers to reusable-security-suite@v1.25.0

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -40,5 +40,4 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      checks: read # report job reads zizmor check-run annotations
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@39820bb4238be1f3160e8d705c7c2942013711cb # v1.24.0
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@d3e2831cf22c560198fc511fbb0a1be5c7361d2a # v1.25.0

--- a/workflow-templates/security-suite.yml
+++ b/workflow-templates/security-suite.yml
@@ -33,5 +33,4 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      checks: read # report job reads zizmor check-run annotations
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@39820bb4238be1f3160e8d705c7c2942013711cb # v1.24.0
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@d3e2831cf22c560198fc511fbb0a1be5c7361d2a # v1.25.0


### PR DESCRIPTION
Points the thin callers (security-suite.yml + picker template) at reusable-security-suite@v1.25.0, activating the robust in-job zizmor severity split (#83) through the ruleset. Also drops the now-unneeded `checks: read` from the caller suite jobs. Part of geolonia-operations#196.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security workflow to a newer pinned version.
  * No changes to app behavior, triggers, or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->