### PR TITLE
feat: zizmor severity breakdown in the suite summary (errors/warnings/notices)

### DIFF
--- a/.github/workflows/reusable-security-suite.yml
+++ b/.github/workflows/reusable-security-suite.yml
@@ -76,9 +76,12 @@ jobs:
     outputs:
       # ok when zizmor exits clean, warn otherwise (warn-only rollout).
       status: ${{ steps.zizmor.outcome == 'success' && 'ok' || 'warn' }}
-      # true when the high-severity pass found error-severity issues, so the
-      # summary can flag errors distinctly (computed in-job, no Checks API).
-      has-errors: ${{ steps.zizmor-high.outcome == 'failure' && 'true' || 'false' }}
+      # finding counts by severity level (error / warning / notice) from the
+      # SARIF count pass, so the summary shows the full breakdown. Computed
+      # in-job (no Checks API), same zizmor version + config as the run above.
+      errors: ${{ steps.counts.outputs.errors }}
+      warnings: ${{ steps.counts.outputs.warnings }}
+      notices: ${{ steps.counts.outputs.notices }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -117,25 +120,26 @@ jobs:
           # public, internal, and private repos.
           advanced-security: false
           annotations: true
-          # The zizmor CLI version is left at the action default ("latest"),
-          # which the SHA-pinned action resolves to a fixed, digest-pinned
-          # image. So the version is reproducible and supply-chain pinned by
-          # the action SHA, and Dependabot advances it when it bumps the
-          # action. Do not request a CLI version newer than the pinned
-          # action knows, or it fails with "Unknown version".
-      - name: Detect error-severity findings
-        id: zizmor-high
-        # A second pass at min-severity: high. Its outcome (failure = found
-        # high-severity issues) drives the summary's error vs warning split,
-        # computed in-job so the report job needs no Checks API access.
-        # annotations: false so it does not duplicate the inline annotations
-        # from the run above; it reuses the same auto-discovered zizmor.yml.
+          # Pin the zizmor CLI so the inline annotations match the SARIF
+          # count pass below (which pins the same version). v0.5.7 knows
+          # 1.26.1. Bump both together (Dependabot bumps the action SHA).
+          version: "1.26.1"
+      - name: Count findings by severity
+        id: counts
+        # A second zizmor pass emitting SARIF so the summary can show the
+        # error / warning / notice breakdown. Same pinned version and the
+        # same auto-discovered zizmor.yml as the run above, so the counts
+        # match the inline annotations. Computed in-job (no Checks API).
+        # pipx is preinstalled on GitHub-hosted runners.
         continue-on-error: true
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
-        with:
-          advanced-security: false
-          annotations: false
-          min-severity: high
+        run: |
+          pipx run --spec "zizmor==1.26.1" zizmor --persona regular --format sarif . > zizmor.sarif 2>/dev/null || true
+          count() { local n; n=$(jq --arg L "$1" '[.runs[]?.results[]? | select(.level == $L)] | length' zizmor.sarif 2>/dev/null); echo "${n:-0}"; }
+          {
+            echo "errors=$(count error)"
+            echo "warnings=$(count warning)"
+            echo "notices=$(count note)"
+          } >> "$GITHUB_OUTPUT"
 
   report:
     name: Security Suite summary
@@ -160,7 +164,9 @@ jobs:
           SECRET_TOTAL: ${{ needs.secret-leak.outputs.total }}
           PIN_STATUS: ${{ needs.action-pinning.outputs.status }}
           ZIZMOR_STATUS: ${{ needs.actions-audit.outputs.status }}
-          ZIZMOR_HAS_ERRORS: ${{ needs.actions-audit.outputs.has-errors }}
+          ZIZMOR_ERRORS: ${{ needs.actions-audit.outputs.errors }}
+          ZIZMOR_WARNINGS: ${{ needs.actions-audit.outputs.warnings }}
+          ZIZMOR_NOTICES: ${{ needs.actions-audit.outputs.notices }}
         run: |
           set -euo pipefail
           MARKER="<!-- security-suite-v1 -->"
@@ -200,10 +206,10 @@ jobs:
             *) PIN_MSG="Did not complete" ;;
           esac
 
-          # zizmor is warn-only, but distinguish error-severity from warning-
-          # severity findings so the summary does not understate errors. The
-          # actions-audit job computes has-errors in-job (a second min-severity:
-          # high pass), so no Checks-API read is needed here.
+          # zizmor is warn-only. Show the full severity breakdown (from the
+          # SARIF count pass) so errors are never understated as warnings.
+          ZE="${ZIZMOR_ERRORS:-0}"; ZW="${ZIZMOR_WARNINGS:-0}"; ZN="${ZIZMOR_NOTICES:-0}"
+          ZIZMOR_BREAKDOWN="${ZE} error(s), ${ZW} warning(s), ${ZN} notice(s) (warn-only; see annotations)"
           if [ "${ZIZMOR_STATUS}" = "ok" ]; then
             ZIZMOR_GLYPH="✅"; ZIZMOR_SEV="ok"; ZIZMOR_MSG="No findings"
           elif [ "${ZIZMOR_STATUS}" != "warn" ]; then
@@ -211,12 +217,14 @@ jobs:
             # publish outputs, e.g. it failed/was skipped) -> surface it as a
             # scan error, not warning-only findings.
             ZIZMOR_GLYPH="🟠"; ZIZMOR_SEV="error"; ZIZMOR_MSG="Scan error (see run)"
-          elif [ "${ZIZMOR_HAS_ERRORS}" = "true" ]; then
-            ZIZMOR_GLYPH="❗"; ZIZMOR_SEV="error"
-            ZIZMOR_MSG="Error-severity findings (warn-only; see annotations)"
+          elif [ "${ZE}" -gt 0 ]; then
+            ZIZMOR_GLYPH="❗"; ZIZMOR_SEV="error"; ZIZMOR_MSG="${ZIZMOR_BREAKDOWN}"
+          elif [ "${ZW}" -gt 0 ] || [ "${ZN}" -gt 0 ]; then
+            ZIZMOR_GLYPH="⚠️"; ZIZMOR_SEV="warn"; ZIZMOR_MSG="${ZIZMOR_BREAKDOWN}"
           else
-            ZIZMOR_GLYPH="⚠️"; ZIZMOR_SEV="warn"
-            ZIZMOR_MSG="Warning-severity findings (warn-only; see annotations)"
+            # status=warn but counts came back 0 (e.g. the count pass failed);
+            # do not claim "no findings".
+            ZIZMOR_GLYPH="⚠️"; ZIZMOR_SEV="warn"; ZIZMOR_MSG="Findings (warn-only; see annotations)"
           fi
 
           # Overall callout. Hard gates (bumblebee/betterleaks/pinact) can


### PR DESCRIPTION
The summary row now shows the full zizmor breakdown, e.g. `6 error(s), 8 warning(s), 8 notice(s)`, instead of just the error/warning distinction. A SARIF count pass (pipx zizmor pinned to 1.26.1, matching the action's now-pinned version + the same auto-discovered zizmor.yml) counts all three annotation levels in-job; errors still escalate the callout to [!CAUTION]. Keeps the SHA-pinned action for the inline annotations. After release: chain-bump the callers. Part of geolonia-operations#196 / #200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security scan reporting so warnings and errors are counted more accurately before being shown in automated comments.
  * Updated the scan summary logic to better reflect the actual severity of findings, reducing misleading status messages.
  * Kept the existing warning-focused behavior, while making the reported result more consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->