### PR TITLE
feat: float Security Suite self-references on @v1 (end the release treadmill)

### DIFF
--- a/.github/workflows/reusable-security-suite.yml
+++ b/.github/workflows/reusable-security-suite.yml
@@ -33,6 +33,11 @@ name: "[REUSABLE] Security Suite"
 # Rollout ramp: zizmor runs warn-only (its step is continue-on-error) so we
 # can observe findings org-wide before blocking. Flip to enforce by removing
 # continue-on-error from the Run zizmor step.
+#
+# Pinning: the sibling scanner reusables below float on our major tag (@v1) so
+# a scanner change ships without bumping this file; the org .pinact.yml exempts
+# geolonia/.github reusables at a major tag from SHA-pinning. Third-party
+# actions used inside jobs (checkout, zizmor-action) stay SHA-pinned as normal.
 
 on:
   workflow_call:
@@ -46,7 +51,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@df41a3d00b065911c95265251a6747b4108fc57c # v1.21.0
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@v1
     with:
       report-mode: summary
 
@@ -54,14 +59,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@df41a3d00b065911c95265251a6747b4108fc57c # v1.21.0
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
     with:
       report-mode: summary
 
   action-pinning:
     permissions:
       contents: read
-    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@df41a3d00b065911c95265251a6747b4108fc57c # v1.21.0
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@v1
     with:
       # Warn-only in the suite: an unpinned or comment-mismatched action
       # reports a warning row instead of blocking the PR. (pinact also

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -40,4 +40,9 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@d3e2831cf22c560198fc511fbb0a1be5c7361d2a # v1.25.0
+    # Float on the major tag: a vX.Y.Z release fast-forwards @v1, so this
+    # caller picks up every suite change with no chain-bump. This is a
+    # same-repo reference to our own reusable; the org .pinact.yml exempts
+    # geolonia/.github reusables at a major tag from SHA-pinning (third-party
+    # actions stay pinned). See .pinact.yml for the rationale.
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@v1

--- a/.pinact.yml
+++ b/.pinact.yml
@@ -58,3 +58,22 @@ rules:
     conditions:
       - expr: |
           ActionName matches "geolonia/.*"
+  # Let geolonia/.github reusable workflows float on a major tag (v1, v2, ...)
+  # instead of being SHA-pinned. Our reusables use bot-moved major tags by
+  # design (a vX.Y.Z push fast-forwards vX), so a caller pinned to @v1 always
+  # gets the newest release with no chain-bump. That is what the org "Security
+  # Suite" ruleset relies on: security-suite.yml -> reusable-security-suite.yml
+  # -> the scanner reusables, all at @v1, so a suite change ships in one
+  # release instead of a caller-bump-per-release treadmill.
+  #
+  # Scope and safety: this only exempts references TO geolonia/.github
+  # reusables at a bare major tag (^v[0-9]+$). SHA pins still pass (ignore
+  # never forces un-pinning), and mutable refs like @main or a branch are
+  # still flagged. We already exempt geolonia/* from the 7-day cooldown above
+  # on the same "we author and control these releases" basis; a hijacked @v1
+  # here is the same threat as this repo being compromised. Third-party
+  # actions remain SHA-pinned as normal.
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionRepoFullName == "geolonia/.github" && ActionVersion matches "^v[0-9]+$"

--- a/.pinact.yml
+++ b/.pinact.yml
@@ -66,14 +66,15 @@ rules:
   # -> the scanner reusables, all at @v1, so a suite change ships in one
   # release instead of a caller-bump-per-release treadmill.
   #
-  # Scope and safety: this only exempts references TO geolonia/.github
+  # Scope and safety: this only exempts references to geolonia org actions and
   # reusables at a bare major tag (^v[0-9]+$). SHA pins still pass (ignore
   # never forces un-pinning), and mutable refs like @main or a branch are
-  # still flagged. We already exempt geolonia/* from the 7-day cooldown above
-  # on the same "we author and control these releases" basis; a hijacked @v1
-  # here is the same threat as this repo being compromised. Third-party
-  # actions remain SHA-pinned as normal.
+  # still flagged. It reuses the same `geolonia/*` scope as the cooldown
+  # exemption above, on the same "we author and control these releases" basis;
+  # a hijacked @v1 here is the same threat as this repo being compromised.
+  # (The org zizmor.yml mirrors this with an unpinned-uses ref-pin policy for
+  # `geolonia/*`.) Third-party actions remain SHA-pinned as normal.
   - ignore: true
     conditions:
       - expr: |
-          ActionRepoFullName == "geolonia/.github" && ActionVersion matches "^v[0-9]+$"
+          ActionName matches "geolonia/.*" && ActionVersion matches "^v[0-9]+$"

--- a/workflow-templates/security-suite.yml
+++ b/workflow-templates/security-suite.yml
@@ -5,7 +5,8 @@ name: Security Suite
 # and posts a single consolidated PR comment.
 #
 # This is a thin caller of the org reusable, so it stays current as the
-# suite evolves; Dependabot bumps the pinned ref below.
+# suite evolves: it floats on the reusable's major tag (@v1), which a
+# vX.Y.Z release fast-forwards, so there is nothing to bump here.
 #
 # Note: if your repo is already covered by the org "Security Suite" ruleset,
 # you do not need this file (it would run the suite twice). Use this template
@@ -33,4 +34,4 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@d3e2831cf22c560198fc511fbb0a1be5c7361d2a # v1.25.0
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@v1

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -19,4 +19,25 @@
 #   template-injection:
 #     ignore:
 #       - route-issue.yml   # title/body only reaches a trusted internal step
-rules: {}
+rules:
+  # unpinned-uses policies are matched by repo pattern (owner/repo, owner/*,
+  # *), NOT by filename, so this applies org-wide (unlike the `ignore` list
+  # above). Our own reusable workflows float on a bot-moved major tag (@v1)
+  # by design: a vX.Y.Z release fast-forwards vX, so a symbolic ref is the
+  # intended state for them. Allow ref-pin for the geolonia org and keep the
+  # strict hash-pin blanket policy for every other (third-party) action.
+  # Mirrors the matching .pinact.yml exemption; see that file for the full
+  # rationale.
+  #
+  # Scope note: this uses the owner glob `geolonia/*`, not an exact repo. A
+  # reusable-workflow `uses:` carries the full path (geolonia/.github/.github/
+  # workflows/x.yml), which zizmor's exact `owner/repo` pattern does not
+  # match; only the owner glob does. This lines up with pinact's own `geolonia/*`
+  # scope. ref-pin also permits a branch ref like @main, but pinact still
+  # flags anything other than a bare major tag, so the combined gate keeps
+  # mutable refs out.
+  unpinned-uses:
+    config:
+      policies:
+        "geolonia/*": ref-pin
+        "*": hash-pin


### PR DESCRIPTION
## Why

The org Security Suite chains **three tiers** of same-repo SHA pins:

```
security-suite.yml            (ruleset entry, pinned reusable-security-suite@v1.25.0)
  -> reusable-security-suite.yml   (pinned reusable-bumblebee/secret-leak/pinact@v1.21.0)
    -> the scanner reusables
```

Because pinact required each self-reference to be SHA-pinned, **every** suite change needed a release *and* a caller chain-bump PR + a second release. That treadmill is why we've cut v1.22 -> v1.26 for small iterations, and it's about to bite again for the just-merged #85 zizmor severity breakdown (not yet live because the caller still pins `@v1.25.0`).

## What

- **`.pinact.yml`**: new `rules` entry with `ignore: true` that exempts references **to `geolonia/.github` reusables at a bare major tag** (`^v[0-9]+$`) from SHA-pinning. This is the pinact-recommended mechanism (over `ignore_actions`) and sits alongside the existing `geolonia/*` cooldown exemption.
- Switch all three tiers to `@v1`:
  - `security-suite.yml` (ruleset entry)
  - `workflow-templates/security-suite.yml` (picker copy)
  - the sibling scanner refs inside `reusable-security-suite.yml`

A `vX.Y.Z` release fast-forwards `@v1`, so every caller now picks up suite changes with **no chain-bump**. The org ruleset already targets `security-suite.yml@refs/tags/v1`, so the chain floats end to end.

## Safety / scope

- `ignore: true` **skips** pin/update/error; it does **not** force un-pinning. Existing SHA pins still pass.
- Mutable refs (`@main`, a branch) are **still flagged** — only the bot-moved major tags (`^v[0-9]+$`) are allowed to float.
- **Third-party actions stay SHA-pinned** (checkout, zizmor-action, etc.) — the rule is keyed on `ActionRepoFullName == "geolonia/.github"`.
- Same basis as the existing 7-day cooldown exemption for `geolonia/*`: we author and control these releases; a hijacked `@v1` here is the same threat as this repo being compromised.

## Validation

- `pinact run --check` (v4.1.0) passes locally.
- Negative test: removing the rule makes pinact flag all 5 `@v1` refs (exit 1), confirming the rule is load-bearing and third-party pins are untouched.

## Follow-up

After merge, cut **v1.27.0**. `@v1` moves to it, which also makes the #85 severity breakdown live org-wide. No v1.28.0 chain-bump needed, and future suite tweaks are a single PR + release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security suite workflows now follow the latest `v1` release automatically, reducing the need for manual updates.
  * Added support for floating major-tag references in approved reusable workflow calls.

* **Documentation**
  * Updated comments to clarify which actions stay pinned and which are intended to float with releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->