### PR TITLE
fix: drive geolonia/.github zizmor findings to zero (harden shared workflows)

### DIFF
--- a/.github/workflows/publish-techdocs.yml
+++ b/.github/workflows/publish-techdocs.yml
@@ -10,5 +10,14 @@ on:
 
 jobs:
   publish:
+    # Explicit least-privilege ceiling for the reusable (OIDC publish +
+    # checkout); avoids the repo-default token (zizmor excessive-permissions).
+    permissions:
+      contents: read
+      id-token: write
     uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
-    secrets: inherit
+    # Pass only the secrets the reusable declares, not `secrets: inherit`
+    # (zizmor secrets-inherit). Both are optional (empty when unset).
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      TECHDOCS_AWS_ACCOUNT_ID: ${{ secrets.TECHDOCS_AWS_ACCOUNT_ID }}

--- a/.github/workflows/reusable-backstage-techdocs.yml
+++ b/.github/workflows/reusable-backstage-techdocs.yml
@@ -91,6 +91,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag || github.ref }}
+          # Docs are built from the checkout and published to S3 via OIDC;
+          # the checkout git credentials are never reused, so drop them
+          # (zizmor artipacked).
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -99,7 +103,10 @@ jobs:
           package-manager-cache: false
 
       - name: Install TechDocs CLI
-        run: npm i -g @techdocs/cli@${{ env.TECHDOCS_CLI_VER }}
+        # Reference the workflow-level env as a shell var (not a ${{ }}
+        # expansion) so it never expands into the script (zizmor
+        # template-injection).
+        run: npm i -g "@techdocs/cli@${TECHDOCS_CLI_VER}"
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -109,7 +116,7 @@ jobs:
       - name: Install MkDocs + TechDocs core
         run: |
           python -m pip install --upgrade pip
-          pip install "mkdocs-techdocs-core${{ env.MKDOCS_CORE_VER }}"
+          pip install "mkdocs-techdocs-core${MKDOCS_CORE_VER}"
           pip install "mkdocs-git-revision-date-localized-plugin>=1,<2"
 
       - name: Resolve TechDocs entity from catalog-info.yaml (fallback)
@@ -120,12 +127,16 @@ jobs:
             cmd: yq -r 'select(.kind == "Component") | [.metadata.namespace // "default", (.kind // "Component" | downcase), .metadata.name] | join("/")' catalog-info.yaml
 
       - name: Get final TECHDOCS_ENTITY
+        env:
+          # Indirect the step output through env so it is not expanded into
+          # the script (zizmor template-injection).
+          TECHDOCS_ENTITY_YAML: ${{ steps.techdocs_entity_yaml.outputs.result }}
         run: |
           # Precedence:
           # 1) workflow input
           # 2) repo/org variable
           # 3) catalog-info.yaml
-          ENTITY="${TECHDOCS_ENTITY_INPUT:-${TECHDOCS_ENTITY_VAR:-${{ steps.techdocs_entity_yaml.outputs.result }}}}"
+          ENTITY="${TECHDOCS_ENTITY_INPUT:-${TECHDOCS_ENTITY_VAR:-${TECHDOCS_ENTITY_YAML}}}"
 
           if [ -z "$ENTITY" ]; then
             echo "ERROR: Could not resolve TECHDOCS_ENTITY (no input, no var, catalog-info.yaml missing metadata.name?)"

--- a/.github/workflows/reusable-bumblebee-scan.yml
+++ b/.github/workflows/reusable-bumblebee-scan.yml
@@ -310,8 +310,10 @@ jobs:
 
       - name: Fail the job if findings + fail-on-findings
         if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0' && inputs.fail-on-findings == true
+        env:
+          TOTAL: ${{ steps.findings.outputs.total }}
         run: |
-          echo "::error::Bumblebee scan failed: ${{ steps.findings.outputs.total }} exposure match(es) found."
+          echo "::error::Bumblebee scan failed: ${TOTAL} exposure match(es) found."
           exit 1
 
       - name: Surface scan-level failure

--- a/.github/workflows/reusable-release-auto-on-tag.yml
+++ b/.github/workflows/reusable-release-auto-on-tag.yml
@@ -78,9 +78,16 @@ jobs:
       - name: Parse tag (semver)
         id: semver
         shell: bash
+        env:
+          # Indirect through env so the values never expand into the shell
+          # source (zizmor template-injection). tag_override wins when set,
+          # else the pushed tag ref.
+          TAG_OVERRIDE: ${{ inputs.tag_override }}
+          REF_NAME: ${{ github.ref_name }}
+          TAG_PATTERN: ${{ inputs.tag_pattern }}
         run: |
-          TAG="${{ inputs.tag_override != '' && inputs.tag_override || github.ref_name }}"
-          PATTERN="${{ inputs.tag_pattern }}"
+          TAG="${TAG_OVERRIDE:-$REF_NAME}"
+          PATTERN="$TAG_PATTERN"
           if [[ ! "$TAG" =~ $PATTERN ]]; then
             echo "Tag '$TAG' does not match expected pattern: $PATTERN"
             exit 1
@@ -126,27 +133,36 @@ jobs:
         with:
           client-id: ${{ secrets.WORKFLOWS_CLIENT_ID }}
           private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          # Least privilege: this token only force-pushes the moved vX / vX.Y
+          # tags, which is a contents write. Scope it so a leak cannot touch
+          # anything else the app is installed for.
+          permission-contents: write
 
       - name: Use App token for pushes
+        env:
+          GH_APP_TOKEN: ${{ steps.app_token.outputs.token }}
+          REPO: ${{ github.repository }}
         run: |
-          git remote set-url origin "https://x-access-token:${{ steps.app_token.outputs.token }}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${GH_APP_TOKEN}@github.com/${REPO}.git"
           git config user.name  "geolonia-release[app]"
           git config user.email "geolonia-release[app]@users.noreply.github.com"
 
       - name: Move/update MINOR tag (vX.Y)
         if: ${{ inputs.move_minor_tag }}
         shell: bash
+        env:
+          MINOR: ${{ steps.semver.outputs.minor }}
+          TAG: ${{ steps.semver.outputs.tag }}
         run: |
-          MINOR="${{ steps.semver.outputs.minor }}"
-          TAG="${{ steps.semver.outputs.tag }}"
           git tag -f "$MINOR" "$TAG"
           git push -f origin "$MINOR"
 
       - name: Move/update MAJOR tag (vX)
         if: ${{ inputs.move_major_tag }}
         shell: bash
+        env:
+          MAJOR: ${{ steps.semver.outputs.major }}
+          TAG: ${{ steps.semver.outputs.tag }}
         run: |
-          MAJOR="${{ steps.semver.outputs.major }}"
-          TAG="${{ steps.semver.outputs.tag }}"
           git tag -f "$MAJOR" "$TAG"
           git push -f origin "$MAJOR"

--- a/.github/workflows/reusable-release-auto-on-tag.yml
+++ b/.github/workflows/reusable-release-auto-on-tag.yml
@@ -72,7 +72,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          persist-credentials: true
+          # Do not leave the GITHUB_TOKEN auth config on disk. checkout's
+          # persisted `http.<host>.extraheader` would otherwise override the
+          # App-token URL set in "Use App token for pushes", so the tag moves
+          # could push as GITHUB_TOKEN instead of the App (which is the
+          # identity allowed to bypass the tag-immutability ruleset). Nothing
+          # between here and that step uses the checkout credentials.
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Parse tag (semver)

--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -283,19 +283,21 @@ jobs:
           BODY_FILE: ${{ steps.comment.outputs.body_file }}
           MARKER: ${{ steps.comment.outputs.marker }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
         run: |
           # Probe write access first so we emit a clean warning rather
           # than a noisy 403 from the actual write call.
-          if ! gh api "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" \
+          if ! gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
                 --jq '.permission' >/dev/null 2>&1; then
             : # Probe doesn't have to succeed; fall through and try.
           fi
-          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --paginate --slurp \
             --jq "[.[].[] | select(.body | startswith(env.MARKER))] | .[0].id // empty" \
             2>/dev/null || true)
           if [ -n "${EXISTING}" ]; then
-            if gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+            if gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" \
                  -f body="$(cat "${BODY_FILE}")" >/dev/null 2>&1; then
               echo "Updated existing betterleaks comment (#${EXISTING})."
             else
@@ -320,8 +322,10 @@ jobs:
 
       - name: Fail the job if findings + fail-on-findings
         if: always() && steps.findings.outputs.scan_failed != 'true' && steps.findings.outputs.total != '0' && inputs.fail-on-findings == true
+        env:
+          TOTAL: ${{ steps.findings.outputs.total }}
         run: |
-          echo "::error::Secret-leak check failed: ${{ steps.findings.outputs.total }} potential secret(s) in PR diff."
+          echo "::error::Secret-leak check failed: ${TOTAL} potential secret(s) in PR diff."
           exit 1
 
       - name: Surface scan-level failure

--- a/.github/workflows/reusable-sync-team-access.yml
+++ b/.github/workflows/reusable-sync-team-access.yml
@@ -36,6 +36,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # This job only reads catalog-info.yaml and dispatches via an App
+          # token; it never uses the checkout credentials for git, so do not
+          # leave them on disk (zizmor artipacked).
+          persist-credentials: false
 
       - name: Install yq
         uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
@@ -87,6 +92,10 @@ jobs:
           private-key: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
           repositories: ${{ steps.target.outputs.repo_name }}
           owner: ${{ github.repository_owner }}
+          # Least privilege: the token only sends a repository_dispatch to the
+          # central repo, which needs contents write. Already narrowed to a
+          # single repo above; also narrow the permission set.
+          permission-contents: write
 
       - name: Dispatch sync request
         env:

--- a/.github/workflows/route-issue.yml
+++ b/.github/workflows/route-issue.yml
@@ -10,7 +10,11 @@ permissions:
 jobs:
   route:
     uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
-    secrets: inherit
+    # Pass only the dispatch secrets the reusable declares, not
+    # `secrets: inherit` (zizmor secrets-inherit).
+    secrets:
+      OPS_DISPATCH_CLIENT_ID: ${{ secrets.OPS_DISPATCH_CLIENT_ID }}
+      OPS_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
     # When this repo's issues get an org Department field value, they are added
     # to the matching team project board. Routing config and credentials stay
     # private in geolonia-operations; this repo only forwards the event.

--- a/workflow-templates/publish-techdocs.yml
+++ b/workflow-templates/publish-techdocs.yml
@@ -24,6 +24,11 @@ on:
 
 jobs:
   publish:
+    # Explicit least-privilege ceiling for the reusable (OIDC publish +
+    # checkout); avoids the repo-default token (zizmor excessive-permissions).
+    permissions:
+      contents: read
+      id-token: write
     uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/workflow-templates/route-issue.yml
+++ b/workflow-templates/route-issue.yml
@@ -10,7 +10,11 @@ permissions:
 jobs:
   route:
     uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
-    secrets: inherit
+    # Pass only the dispatch secrets the reusable declares, not
+    # `secrets: inherit` (zizmor secrets-inherit).
+    secrets:
+      OPS_DISPATCH_CLIENT_ID: ${{ secrets.OPS_DISPATCH_CLIENT_ID }}
+      OPS_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
     # When you set an issue's org Department field, the issue is added to that
     # team's project board. Keep this workflow on the default branch so the
     # issues trigger fires.

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -41,3 +41,10 @@ rules:
       policies:
         "geolonia/*": ref-pin
         "*": hash-pin
+  # Accepted: the TechDocs publish job installs its build toolchain
+  # (@techdocs/cli via npm, mkdocs plugins via pip) at run time. These
+  # publishing tools are not part of any repo lockfile, so an ad-hoc install
+  # is expected. Scoped to the filename (zizmor `ignore` is exact-basename).
+  adhoc-packages:
+    ignore:
+      - reusable-backstage-techdocs.yml


### PR DESCRIPTION
Clears **all 22** zizmor findings in this repo's own workflows (**6 error / 5 warning / 11 note**). Most live in **shared workflows copied into other repos**, so fixing them here reduces the org-wide ~122 backlog at the source.

## Disposition (per the agreed triage)

| Rule | Count | Fix |
|:--|:--|:--|
| `template-injection` | 14 | Move `github.*` / `steps.*` / `inputs.*` out of `run:` into `env:` + shell vars (or `env.*` in `with:`, which zizmor accepts). Behavior-preserving. |
| `github-app` | 2 | **Harden** — scope App tokens to `permission-contents: write` (release = tag push; team-sync = repository_dispatch, both contents writes). |
| `artipacked` | 2 | `persist-credentials: false` on the sync-team-access + techdocs checkouts (neither reuses the checkout git creds). |
| `excessive-permissions` | 1 | Explicit `permissions:` on `publish-techdocs.yml`. |
| `secrets-inherit` | 2 | **Pass explicit secrets** instead of `secrets: inherit` (route-issue → `OPS_DISPATCH_*`; publish-techdocs → AWS account ids). Applied to dogfood copies **and** templates. |
| `adhoc-packages` | 1 | **Accept** — TechDocs build installs `@techdocs/cli` + mkdocs plugins at run time (no repo lockfile); justified ignore in `zizmor.yml`. |

## ⚠️ Watch on release

The **App-token scoping** in `reusable-release-auto-on-tag.yml` is exercised the next time a `vX.Y.Z` tag is pushed — in this repo **and**, via `@v1`, every repo that calls the reusable to move its floating tags. I scoped it to `permission-contents: write`, which is exactly what the two `git push -f` tag moves need. **When we cut v1.28.0 after this merges, confirm `@v1` actually advanced** (that proves the scoped token can still push tags). Same for `permission-contents: write` on the team-sync dispatch token.

## Validation
- `uvx zizmor --persona regular .` → **No findings** (1 ignored, 31 `geolonia/*` ref-pins suppressed).
- `pinact run --check` → exit 0 (no ref/pin regressions).

## Not in scope
- The `--slurp` + `--jq` double-post latent bug in the comment-post steps (separate concern).
- Bumping the stale `@v1.16.0` refs in route-issue/publish-techdocs to `@v1` (now allowed by #86) — tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow security by tightening job permissions and limiting which secrets are forwarded to reusable jobs.
  * Reduced the risk of credential/permission issues during checkout by disabling persisted credentials where applicable.
  * Updated automation steps to use safer environment-variable handling for tag parsing, TechDocs publishing, and scan/comment outputs.
* **Chores**
  * Added a narrowly scoped allow-list exception for a specific TechDocs workflow in the security scan configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->