### PR TITLE
fix: pin required-workflow reusable ref to a SHA (unbreak org-wide Security Suite)

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -40,9 +40,13 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    # Float on the major tag: a vX.Y.Z release fast-forwards @v1, so this
-    # caller picks up every suite change with no chain-bump. This is a
-    # same-repo reference to our own reusable; the org .pinact.yml exempts
-    # geolonia/.github reusables at a major tag from SHA-pinning (third-party
-    # actions stay pinned). See .pinact.yml for the rationale.
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@v1
+    # MUST be an immutable ref (SHA), NOT a floating @v1. This file is the
+    # org "required workflow" (ruleset "require workflows"); the required-
+    # workflow injector refuses to run when the required workflow's own
+    # reusable is referenced by a moving tag, so a @v1 here silently produces
+    # NO run and the required check hangs at "Expected" forever on every
+    # consumer PR. Pinning to a release SHA is what makes the gate actually
+    # fire. The inner scanner refs inside reusable-security-suite.yml stay at
+    # @v1 (they resolve fine at runtime); only this top-level required-workflow
+    # reference must be pinned. Bump this SHA on each suite release.
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@82a98a9b4b4f75f1f064a85a7ebc720bbcc953f5 # v1.28.0


### PR DESCRIPTION
## Regression (org-wide, urgent)

Since #86 / v1.27.0, the **Security Suite required check never runs on consumer PRs** — it hangs at *"Expected — waiting for workflow to run"* forever and blocks merge (e.g. [geolonia-infra-cdk#151](https://github.com/geolonia/geolonia-infra-cdk/pull/151)).

## Root cause

#86 changed the org **required workflow** `security-suite.yml` to reference its reusable via a floating **`@v1`** (was a SHA pin). The ruleset "require workflows" **injector does not run a required workflow whose own reusable is a moving tag** — it silently produces *no run at all* (no check-run, not even a failure), so the required check stays "Expected".

**Evidence it's exactly this one ref:**
- The only diff between the last-working release (v1.26.0, SHA-pinned) and current `@v1` (v1.28.0, floating) is this single `uses:` line.
- On infra-cdk#151's head there is **no Security Suite run** — only `ci.yml`.
- Every consumer's last suite run was **before** `@v1` moved to v1.27.0.
- #87's **own** suite CI ran green with the full `@v1` chain as a *normal* workflow — proving the inner `reusable-security-suite → sub-reusables@v1` (REF3) resolves fine at runtime. Only the top-level required-workflow reference (REF2) is affected.

## Fix (surgical, one line)

SHA-pin **only** the required workflow's reusable ref:
```
uses: …/reusable-security-suite.yml@82a98a9…  # v1.28.0   (was @v1)
```
- Inner scanner refs (`reusable-security-suite → sub-reusables`) **stay `@v1`** — they float fine at runtime.
- `workflow-templates/security-suite.yml` **stays `@v1`** — adopted as a normal workflow, moving tags work there.

## Tradeoff

The treadmill returns **only one level**: bump this SHA when `reusable-security-suite.yml` itself changes. Sub-reusable changes (the frequent ones) still propagate via `@v1` with no bump. This is arguably correct anyway — an org-wide required gate *should* pin its entrypoint reusable immutably.

## After merge
Cut **v1.29.0** → `@v1` advances → re-trigger a consumer PR (empty commit on infra-cdk#151) and confirm the Security Suite check actually runs.

Validation: `pinact --check` exit 0 (the `@v1` exemption still covers REF3 + the template); `zizmor` clean; no em-dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security check workflow to use a fixed, pinned version for more reliable execution on pull requests.
  * Improved workflow configuration so the required security gate runs consistently without hanging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->