### PR TITLE
fix: SHA-pin suite sub-reusables (required-workflow tree must be immutable) [1/2]

### DIFF
--- a/.github/workflows/reusable-security-suite.yml
+++ b/.github/workflows/reusable-security-suite.yml
@@ -34,10 +34,16 @@ name: "[REUSABLE] Security Suite"
 # can observe findings org-wide before blocking. Flip to enforce by removing
 # continue-on-error from the Run zizmor step.
 #
-# Pinning: the sibling scanner reusables below float on our major tag (@v1) so
-# a scanner change ships without bumping this file; the org .pinact.yml exempts
-# geolonia/.github reusables at a major tag from SHA-pinning. Third-party
-# actions used inside jobs (checkout, zizmor-action) stay SHA-pinned as normal.
+# Pinning: the sibling scanner reusables below are SHA-pinned, NOT floated on
+# @v1. This reusable sits in the org "required workflow" tree (security-suite.yml
+# -> here -> scanners), and the ruleset "require workflows" injector runs a
+# required workflow ONLY when its ENTIRE reusable tree is immutably pinned; a
+# moving tag anywhere in the tree makes the injector silently produce no run,
+# so the required check hangs at "Expected" forever on every consumer PR (see
+# .github#88 / the v1.27-v1.29 regression). So bump these SHAs on each release.
+# Third-party actions used inside jobs (checkout, zizmor-action) are SHA-pinned
+# as usual. (workflow-templates/security-suite.yml may still use @v1: it is a
+# normal, non-injected workflow where moving tags resolve fine.)
 
 on:
   workflow_call:
@@ -51,7 +57,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@0d7d0f2ef99869b08f125c075214994a947de901 # v1.29.0
     with:
       report-mode: summary
 
@@ -59,14 +65,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@0d7d0f2ef99869b08f125c075214994a947de901 # v1.29.0
     with:
       report-mode: summary
 
   action-pinning:
     permissions:
       contents: read
-    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@v1
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@0d7d0f2ef99869b08f125c075214994a947de901 # v1.29.0
     with:
       # Warn-only in the suite: an unpinned or comment-mismatched action
       # reports a warning row instead of blocking the PR. (pinact also


### PR DESCRIPTION
**Part 1 of 2** restoring the org Security Suite required check (broken org-wide since #86 / v1.27.0).

## Why
The ruleset "require workflows" injector runs a required workflow **only when its entire reusable tree is immutably pinned**. #86 floated everything on `@v1`; **v1.29.0** (#88) SHA-pinned only the top ref (REF2) and the suite *still* didn't inject — proving the injector also rejects moving tags one level deeper (REF3: `reusable-security-suite → sub-reusables@v1`).

## This PR
SHA-pin the three scanner refs inside `reusable-security-suite.yml` to `@0d7d0f2 # v1.29.0` (includes #87's hardening). Header comment updated to explain the constraint.

## Sequence
- **[1/2] this PR** → release **v1.30.0** (`reusable-security-suite` now has SHA-pinned scanners).
- **[2/2] follow-up** → bump `security-suite.yml`'s REF2 to v1.30.0's SHA → release **v1.31.0**. Whole tree immutable → injector runs → verify on a consumer PR.

`workflow-templates/security-suite.yml` stays `@v1` (normal, non-injected workflow where moving tags resolve fine). Validation: `pinact --check` exit 0, `zizmor` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the reusable security scan workflow to use fixed, pinned versions for its included checks.
  * Improved workflow notes so future updates are clearer and reduce the risk of checks staying in an unexpected pending state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->