### PR TITLE
fix: bump required-workflow ref to v1.30.0 (whole tree now immutable) [2/2]

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -49,4 +49,4 @@ jobs:
     # fire. The inner scanner refs inside reusable-security-suite.yml stay at
     # @v1 (they resolve fine at runtime); only this top-level required-workflow
     # reference must be pinned. Bump this SHA on each suite release.
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@82a98a9b4b4f75f1f064a85a7ebc720bbcc953f5 # v1.28.0
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@76db4b3bd1dca7a263cc82a0837fe6cb1cf2a98e # v1.30.0


### PR DESCRIPTION
**Part 2 of 2** — completes the fix for the org-wide Security Suite required check.

`reusable-security-suite@v1.30.0` (#89) SHA-pinned its scanner refs, so pointing `security-suite.yml`'s reusable ref at it makes the **entire required-workflow reusable tree immutable**:

```
security-suite.yml  → reusable-security-suite@76db4b3 (v1.30.0, SHA)
  reusable-security-suite → sub-reusables@0d7d0f2 (v1.29.0, SHA)
```

This is the same shape as the last-known-working **v1.25.0** (fully SHA-pinned), now with the `#85` severity breakdown + `#87` hardening. The ruleset "require workflows" injector needs exactly this (no moving tags anywhere in the tree).

## After merge
Cut **v1.31.0** → `@v1` advances → re-trigger a consumer PR (infra-cdk#151) → **confirm the Security Suite check finally runs**. That's the real verification; I'll hold the "fixed" call until then.

Validation: `pinact --check` exit 0, `zizmor` clean, no em-dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security suite to a newer pinned version for PR checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->