### PR TITLE
docs: Security Suite required-workflow maintenance (SHA-pin the whole tree)

### DIFF
--- a/.serena/memories/reusable_workflows.md
+++ b/.serena/memories/reusable_workflows.md
@@ -30,6 +30,13 @@ locations** in this repo plus a **tag-pinning convention** in callers.
   `CdkDeployMonitor` IAM permission bundle and `models: read` permission
   in the calling workflow + every parent in the call chain.
 - **`sync-team-access`** - keeps GitHub team-to-repo access in sync.
+- **`security-suite`** - consolidated per-PR security gate (bumblebee,
+  betterleaks, pinact, zizmor) posting ONE PR comment. Enforced org-wide as
+  a ruleset "required workflow" pointing at `security-suite.yml@v1`, so
+  targeted repos need NO file of their own. `security-suite.yml` is a thin
+  caller of `reusable-security-suite.yml`, which calls the scanner reusables.
+  **SPECIAL RELEASE RULES apply - see the warning below. Do not just move
+  `v1`.** Full page: `docs/workflows/security-suite.md`.
 
 ## Caller-side conventions
 
@@ -69,6 +76,40 @@ When making **breaking** changes:
 Always keep `workflow-templates/<name>.properties.json` in sync with the
 YAML so the picker shows accurate names/descriptions.
 
+## SPECIAL CASE: the Security Suite required-workflow tree
+
+The "move `v1` forward" flow above is UNSAFE for `security-suite.yml` and the
+reusables it pulls in. Because it is a ruleset **required workflow**, the
+"require workflows" injector runs it ONLY when its ENTIRE reusable tree
+resolves to immutable SHAs:
+
+```
+security-suite.yml  ->  reusable-security-suite.yml@<SHA>
+                          ->  reusable-{bumblebee-scan,secret-leak-check,pinact-check}.yml@<SHA>
+```
+
+A moving tag (`@v1`) ANYWHERE in that tree makes the injector **silently
+produce no run at all** - no check-run, not even a failure - so the required
+"Security Suite" check hangs at "Expected / waiting for workflow to run"
+FOREVER and blocks merge on every consumer PR. (Learned via the v1.27-v1.29
+regression; fixed in #88/#89/#90.) GitHub's docs do not spell this out.
+
+Rules:
+
+- Keep every `uses:` in the tree above SHA-pinned (with a `# vX.Y.Z` comment).
+  Only the picker template `workflow-templates/security-suite.yml` may stay
+  `@v1` (it is a normal, non-injected workflow).
+- Releasing a suite/scanner change takes TWO releases (the SHAs are a
+  caller->callee chain): (1) pin the scanner refs inside
+  `reusable-security-suite.yml` to the latest release SHA, release `vX`;
+  (2) bump `security-suite.yml`'s ref to `vX`'s SHA, release `vY`.
+- `@v1` fast-forwarding is NOT proof it works (the failure is silent). After
+  release, re-trigger a consumer PR (empty commit) and confirm a
+  "Security Suite" run appears on the new head SHA.
+- `geolonia/.github` must NOT be in the ruleset's target repos (it hosts the
+  required workflow; its own PRs would hang the same way). It dogfoods via its
+  local `security-suite.yml` instead.
+
 ## Common troubleshooting
 
 - **`Could not find reusable workflow`** - caller is pinned to a tag that
@@ -79,3 +120,7 @@ YAML so the picker shows accurate names/descriptions.
   repo, or the per-repo `AWS_ACCOUNT_ID` override is set.
 - **CDK deploy monitor doesn't post comments** - needs `contents: write`
   + `models: read` on the **caller's** top-level `permissions:` block.
+- **Security Suite required check stuck at "Expected"** on consumer PRs, with
+  no "Security Suite" run in the Actions tab - a moving `@v1` ref is present
+  somewhere in the required-workflow tree. SHA-pin every `uses:` in the tree
+  (see the SPECIAL CASE section above).

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -8,6 +8,7 @@ under `.github/workflows/`.
 
 | Template | Page |
 | --- | --- |
+| Security Suite (`security-suite.yml`) | [Security Suite](workflows/security-suite.md) |
 | Publish TechDocs (`publish-techdocs.yml`) | [Publish TechDocs](workflows/publish-techdocs.md) |
 | Release on Tag (`release-auto-on-tag.yml`) | [Release on Tag](workflows/release-on-tag.md) |
 | Bumblebee Supply-Chain Scan (`bumblebee-scan.yml`) | [Bumblebee Supply-Chain Scan](workflows/bumblebee-scan.md) |
@@ -30,6 +31,13 @@ repos making use of them can pin a version and avoid breakage from changes on `m
 Pinning to tags prevents breakage in repos making use of them. When a breaking
 change is needed, publish a new tag (e.g., `v2.1.0`) so repositories can upgrade
 on their own schedule.
+
+> **Exception: the Security Suite required-workflow tree.** `security-suite.yml`
+> is enforced org-wide as a ruleset "required workflow", and that path must be
+> pinned to immutable **SHAs at every level** (a moving `@v1` anywhere in the
+> tree makes the required check hang silently). See
+> [Security Suite](workflows/security-suite.md) before releasing any change to
+> the suite or its scanners.
 
 ## Updating templates
 

--- a/docs/workflows/security-suite.md
+++ b/docs/workflows/security-suite.md
@@ -1,0 +1,104 @@
+# Security Suite
+
+Geolonia's consolidated per-PR security gate. One workflow fans out to four
+scanners and posts a single "Security suite" PR comment:
+
+- **bumblebee** - supply-chain package inventory vs. threat-intel catalogs
+- **betterleaks** - secret-leak gate on the PR diff
+- **pinact** - GitHub Actions SHA-pinning check (warn-only)
+- **zizmor** - GitHub Actions static analysis (warn-only)
+
+## How it is enforced
+
+The suite runs on every targeted repo with **no workflow file in that repo**,
+via an organization **ruleset** ("Require workflows to pass before merging")
+that points at:
+
+```
+geolonia/.github/.github/workflows/security-suite.yml@refs/tags/v1
+```
+
+`security-suite.yml` is a thin caller of `reusable-security-suite.yml`, which
+calls the scanner reusables. The same suite is also offered in the "New
+workflow" picker (`workflow-templates/security-suite.yml`) for repos that opt
+in manually instead of via the ruleset. **Do not enable both on one repo.**
+
+## ⚠️ The one rule you must not forget on a release
+
+**The required-workflow reusable tree must be pinned to immutable SHAs at every
+level. A moving tag (`@v1`) anywhere in the tree silently breaks the gate.**
+
+```
+security-suite.yml              (required workflow, ruleset points here @v1)
+  └─ uses: reusable-security-suite.yml@<SHA>        # MUST be a SHA
+       ├─ uses: reusable-bumblebee-scan.yml@<SHA>   # MUST be a SHA
+       ├─ uses: reusable-secret-leak-check.yml@<SHA> # MUST be a SHA
+       └─ uses: reusable-pinact-check.yml@<SHA>     # MUST be a SHA
+```
+
+Why: the ruleset "require workflows" **injector** runs a required workflow only
+when its **entire** reusable tree resolves to immutable refs. If any ref in the
+tree is a moving tag, the injector **silently produces no run at all** - no
+check-run, not even a failure - and the required "Security Suite" check hangs at
+**"Expected / waiting for workflow to run" forever**, blocking merge on every
+consumer PR. This is not documented clearly by GitHub; it was learned the hard
+way (the v1.27-v1.29 regression, see
+[#88](https://github.com/geolonia/.github/pull/88) /
+[#89](https://github.com/geolonia/.github/pull/89) /
+[#90](https://github.com/geolonia/.github/pull/90)).
+
+This rule applies **only to the required-workflow tree above.** The picker
+template `workflow-templates/security-suite.yml` may keep `@v1` - it is adopted
+as a normal, non-injected workflow, where moving tags resolve fine at runtime.
+
+## Releasing a change to the suite (the two-release dance)
+
+Because `security-suite.yml` pins `reusable-security-suite.yml` by SHA, and that
+file pins the scanners by SHA, a change has to converge over **two releases**
+(the SHAs form a caller → callee chain and cannot both point at the same
+not-yet-created commit):
+
+1. **Change the inner piece + pin.** Edit the scanner reusable (or
+   `reusable-security-suite.yml`), and in `reusable-security-suite.yml` pin the
+   scanner refs to the SHA of the latest release that contains your change.
+   Merge and release (e.g. `vX`).
+2. **Bump the top ref.** In `security-suite.yml`, bump the
+   `reusable-security-suite.yml` ref to `vX`'s SHA. Merge and release (`vY`).
+
+After `vY`, `@v1` fast-forwards to it and the whole tree is immutable again.
+
+Update the pin comment (`@<sha> # vX.Y.Z`) so pinact stays green.
+`.pinact.yml` and `zizmor.yml` exempt `geolonia/*` reusables referenced at a
+bare major tag from pinning **for the template's sake** - do not rely on that
+exemption for the required-workflow tree; that tree must be SHA-pinned.
+
+## Verify after every release
+
+`@v1` moving is **not** proof the gate works - the injector failure is silent.
+After releasing, confirm the suite actually runs on a real consumer PR:
+
+```bash
+# Re-trigger an open consumer PR with an empty commit (synchronize event),
+# then confirm a "Security Suite" run appears on the new head SHA:
+gh api "repos/geolonia/<repo>/actions/runs?head_sha=<head>" \
+  --jq '.workflow_runs[].name'
+```
+
+If you see only the repo's own CI and no "Security Suite" run, the tree still
+has a moving ref somewhere - re-check every `uses:` in the chain above.
+
+## geolonia/.github is not a ruleset target
+
+The repo that **hosts** the required workflow must **not** also be in the
+ruleset's target repos. On its own PRs GitHub runs the local branch copy of
+`security-suite.yml` (the normal job checks), but the injected required check
+expects the `@v1` version and hangs at "Expected". Keep `geolonia/.github`
+excluded from the ruleset targets; it dogfoods the suite via its own
+`.github/workflows/security-suite.yml` instead.
+
+## Troubleshooting
+
+See the shared tips in [Reusable Workflow Templates](../workflows.md#troubleshooting).
+The failure mode unique to this suite is the silent "Expected" hang described
+above; it is almost always a moving ref left somewhere in the required-workflow
+tree.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - Community Health: community-health.md
   - Workflows:
       - Overview: workflows.md
+      - Security Suite: workflows/security-suite.md
       - Publish TechDocs: workflows/publish-techdocs.md
       - Release on Tag: workflows/release-on-tag.md
       - Bumblebee Supply-Chain Scan: workflows/bumblebee-scan.md


### PR DESCRIPTION
Writes down the constraint we just learned the hard way, so the **next release doesn't re-break the org-wide gate**.

The ruleset "require workflows" injector runs the Security Suite only when its **entire reusable tree is SHA-pinned**; a moving `@v1` anywhere makes the required check hang *silently* at "Expected" on every consumer PR (the v1.27–v1.29 regression, #88/#89/#90).

- **New** [`docs/workflows/security-suite.md`](../blob/docs/security-suite-maintenance/docs/workflows/security-suite.md): enforcement model, the SHA-pinning rule (with the tree diagram), the **two-release chain-bump** release procedure, **post-release verification** (re-trigger a consumer PR — `@v1` moving is *not* proof), and why `geolonia/.github` must stay out of the ruleset targets.
- Linked from `docs/workflows.md` (+ an exception callout) and added to the mkdocs nav.
- `.serena/memories/reusable_workflows.md`: adds the suite, a **SPECIAL CASE** section warning that the generic "move `v1` forward" is unsafe for this tree, and a troubleshooting entry for the silent "Expected" hang.

No code changes. No em-dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the new Security Suite workflow, including how it appears in the workflows catalog.
  * Documented the required setup for this org-wide security gate, including strict pinning guidance and how updates should be rolled out safely.
  * Added troubleshooting notes for cases where the required security check appears stuck or doesn’t complete as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->