### PR TITLE
fix: float suite refs on @v1 + keep v1 lightweight + document the real root cause

### DIFF
--- a/.github/workflows/release-auto-on-tag.yml
+++ b/.github/workflows/release-auto-on-tag.yml
@@ -9,7 +9,9 @@ jobs:
   publish:
     permissions:
       contents: write # create the GitHub release and push/move tags
-    uses: geolonia/.github/.github/workflows/reusable-release-auto-on-tag.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
+    # Float on @v1 (this is a normal, non-required workflow) so we pick up the
+    # lightweight-tag peel fix and future release-workflow changes automatically.
+    uses: geolonia/.github/.github/workflows/reusable-release-auto-on-tag.yml@v1
     # Pass only the secrets the reusable declares, not `inherit`.
     secrets:
       WORKFLOWS_CLIENT_ID: ${{ secrets.WORKFLOWS_CLIENT_ID }}

--- a/.github/workflows/reusable-release-auto-on-tag.yml
+++ b/.github/workflows/reusable-release-auto-on-tag.yml
@@ -160,7 +160,11 @@ jobs:
           MINOR: ${{ steps.semver.outputs.minor }}
           TAG: ${{ steps.semver.outputs.tag }}
         run: |
-          git tag -f "$MINOR" "$TAG"
+          # Peel to the commit ("$TAG^{commit}") so the moved tag is always a
+          # LIGHTWEIGHT tag, even when the release tag is annotated. An
+          # annotated floating tag breaks the ruleset required-workflow
+          # injector (see docs/workflows/security-suite.md).
+          git tag -f "$MINOR" "$TAG^{commit}"
           git push -f origin "$MINOR"
 
       - name: Move/update MAJOR tag (vX)
@@ -170,5 +174,7 @@ jobs:
           MAJOR: ${{ steps.semver.outputs.major }}
           TAG: ${{ steps.semver.outputs.tag }}
         run: |
-          git tag -f "$MAJOR" "$TAG"
+          # Peel to the commit so the moved major tag stays lightweight (see
+          # the MINOR step above and docs/workflows/security-suite.md).
+          git tag -f "$MAJOR" "$TAG^{commit}"
           git push -f origin "$MAJOR"

--- a/.github/workflows/reusable-security-suite.yml
+++ b/.github/workflows/reusable-security-suite.yml
@@ -34,16 +34,13 @@ name: "[REUSABLE] Security Suite"
 # can observe findings org-wide before blocking. Flip to enforce by removing
 # continue-on-error from the Run zizmor step.
 #
-# Pinning: the sibling scanner reusables below are SHA-pinned, NOT floated on
-# @v1. This reusable sits in the org "required workflow" tree (security-suite.yml
-# -> here -> scanners), and the ruleset "require workflows" injector runs a
-# required workflow ONLY when its ENTIRE reusable tree is immutably pinned; a
-# moving tag anywhere in the tree makes the injector silently produce no run,
-# so the required check hangs at "Expected" forever on every consumer PR (see
-# .github#88 / the v1.27-v1.29 regression). So bump these SHAs on each release.
-# Third-party actions used inside jobs (checkout, zizmor-action) are SHA-pinned
-# as usual. (workflow-templates/security-suite.yml may still use @v1: it is a
-# normal, non-injected workflow where moving tags resolve fine.)
+# Pinning: the sibling scanner reusables below float on our major tag (@v1) so
+# a scanner change ships without bumping this file; the org .pinact.yml +
+# zizmor.yml exempt geolonia/* reusables at a major tag from pinning.
+# Third-party actions used inside jobs (checkout, zizmor-action) stay SHA-pinned.
+# NB: floating reusable refs are fine for the required-workflow tree. The real
+# constraint is that the `v1` tag must be a LIGHTWEIGHT tag (an annotated `v1`
+# breaks the ruleset injector). See docs/workflows/security-suite.md.
 
 on:
   workflow_call:
@@ -57,7 +54,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@0d7d0f2ef99869b08f125c075214994a947de901 # v1.29.0
+    uses: geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml@v1
     with:
       report-mode: summary
 
@@ -65,14 +62,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@0d7d0f2ef99869b08f125c075214994a947de901 # v1.29.0
+    uses: geolonia/.github/.github/workflows/reusable-secret-leak-check.yml@v1
     with:
       report-mode: summary
 
   action-pinning:
     permissions:
       contents: read
-    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@0d7d0f2ef99869b08f125c075214994a947de901 # v1.29.0
+    uses: geolonia/.github/.github/workflows/reusable-pinact-check.yml@v1
     with:
       # Warn-only in the suite: an unpinned or comment-mismatched action
       # reports a warning row instead of blocking the PR. (pinact also

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -40,13 +40,13 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    # MUST be an immutable ref (SHA), NOT a floating @v1. This file is the
-    # org "required workflow" (ruleset "require workflows"); the required-
-    # workflow injector refuses to run when the required workflow's own
-    # reusable is referenced by a moving tag, so a @v1 here silently produces
-    # NO run and the required check hangs at "Expected" forever on every
-    # consumer PR. Pinning to a release SHA is what makes the gate actually
-    # fire. The inner scanner refs inside reusable-security-suite.yml stay at
-    # @v1 (they resolve fine at runtime); only this top-level required-workflow
-    # reference must be pinned. Bump this SHA on each suite release.
-    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@76db4b3bd1dca7a263cc82a0837fe6cb1cf2a98e # v1.30.0
+    # Float on the major tag so the suite upgrades with no chain-bump. This is
+    # the org "required workflow" (ruleset "require workflows"), and a floating
+    # reusable ref here is FINE. The one hard requirement is that the `v1` tag
+    # itself must be a LIGHTWEIGHT tag: the ruleset resolves this workflow at
+    # `security-suite.yml@refs/tags/v1`, and the required-workflow injector
+    # cannot resolve an ANNOTATED `v1` tag object, which makes the required
+    # check hang silently at "Expected" on every consumer PR. See
+    # docs/workflows/security-suite.md. (org .pinact.yml + zizmor.yml exempt
+    # geolonia/* reusables at a major tag from pinning.)
+    uses: geolonia/.github/.github/workflows/reusable-security-suite.yml@v1

--- a/.serena/memories/reusable_workflows.md
+++ b/.serena/memories/reusable_workflows.md
@@ -30,6 +30,13 @@ locations** in this repo plus a **tag-pinning convention** in callers.
   `CdkDeployMonitor` IAM permission bundle and `models: read` permission
   in the calling workflow + every parent in the call chain.
 - **`sync-team-access`** - keeps GitHub team-to-repo access in sync.
+- **`security-suite`** - consolidated per-PR security gate (bumblebee,
+  betterleaks, pinact, zizmor) posting ONE PR comment. Enforced org-wide as a
+  ruleset "required workflow" at `security-suite.yml@v1`, so targeted repos
+  need NO file of their own. `security-suite.yml` -> `reusable-security-suite.yml`
+  -> the scanner reusables, all floating on `@v1`. **CRITICAL: the `v1` tag
+  must be LIGHTWEIGHT** (see the warning below). Full page:
+  `docs/workflows/security-suite.md`.
 
 ## Caller-side conventions
 
@@ -69,6 +76,32 @@ When making **breaking** changes:
 Always keep `workflow-templates/<name>.properties.json` in sync with the
 YAML so the picker shows accurate names/descriptions.
 
+## CRITICAL: the Security Suite `v1` tag must stay LIGHTWEIGHT
+
+`security-suite.yml` is a ruleset **required workflow** resolved at
+`@refs/tags/v1`. GitHub's "require workflows" injector **cannot resolve an
+ANNOTATED `v1` tag** - it silently produces NO run, and the required
+"Security Suite" check hangs at "Expected / waiting for workflow to run"
+forever on every consumer PR. (This caused an org-wide outage: v1.27-v1.31,
+2026-07. The reusable-ref float-vs-SHA was a RED HERRING; the real cause was
+an annotated `v1`.)
+
+- Cut release tags **lightweight** (`git tag vX.Y.Z`, NOT `git tag -a`). An
+  annotated `vX.Y.Z` gets copied into `v1` by the release workflow's
+  `git tag -f v1 <tag>`.
+- `reusable-release-auto-on-tag.yml` now peels to the commit
+  (`git tag -f v1 "$TAG^{commit}"`) so moved tags are lightweight regardless -
+  keep that.
+- Floating reusable refs (`reusable-security-suite@v1`, scanners `@v1`) are
+  FINE; do NOT SHA-pin them to "fix" an Expected hang - check the `v1` tag
+  type instead:
+  `git ls-remote https://github.com/geolonia/.github refs/tags/v1 'refs/tags/v1^{}'`
+  (annotated if the two SHAs differ).
+- After any suite release, VERIFY on a real consumer PR that a "Security Suite"
+  run appears (`@v1` moving is not proof - the failure is silent).
+- `geolonia/.github` must NOT be in the ruleset's target repos (it hosts the
+  required workflow; its own PRs would hang the same way).
+
 ## Common troubleshooting
 
 - **`Could not find reusable workflow`** - caller is pinned to a tag that
@@ -79,3 +112,7 @@ YAML so the picker shows accurate names/descriptions.
   repo, or the per-repo `AWS_ACCOUNT_ID` override is set.
 - **CDK deploy monitor doesn't post comments** - needs `contents: write`
   + `models: read` on the **caller's** top-level `permissions:` block.
+- **Security Suite required check stuck at "Expected"** on consumer PRs with no
+  "Security Suite" run in Actions - the `v1` tag is ANNOTATED. Recreate it
+  lightweight (`git tag -d v1; git tag v1 <commit>; git push -f origin v1`).
+  See the CRITICAL section above.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -8,6 +8,7 @@ under `.github/workflows/`.
 
 | Template | Page |
 | --- | --- |
+| Security Suite (`security-suite.yml`) | [Security Suite](workflows/security-suite.md) |
 | Publish TechDocs (`publish-techdocs.yml`) | [Publish TechDocs](workflows/publish-techdocs.md) |
 | Release on Tag (`release-auto-on-tag.yml`) | [Release on Tag](workflows/release-on-tag.md) |
 | Bumblebee Supply-Chain Scan (`bumblebee-scan.yml`) | [Bumblebee Supply-Chain Scan](workflows/bumblebee-scan.md) |
@@ -30,6 +31,12 @@ repos making use of them can pin a version and avoid breakage from changes on `m
 Pinning to tags prevents breakage in repos making use of them. When a breaking
 change is needed, publish a new tag (e.g., `v2.1.0`) so repositories can upgrade
 on their own schedule.
+
+> **Security Suite gotcha:** `security-suite.yml` is enforced org-wide as a
+> ruleset "required workflow". Its reusable refs may float on `@v1`, but the
+> `v1` **tag itself must be lightweight** (an annotated `v1` makes the required
+> check hang silently on every consumer PR). See
+> [Security Suite](workflows/security-suite.md) before releasing.
 
 ## Updating templates
 

--- a/docs/workflows/security-suite.md
+++ b/docs/workflows/security-suite.md
@@ -1,0 +1,102 @@
+# Security Suite
+
+Geolonia's consolidated per-PR security gate. One workflow fans out to four
+scanners and posts a single "Security suite" PR comment:
+
+- **bumblebee** - supply-chain package inventory vs. threat-intel catalogs
+- **betterleaks** - secret-leak gate on the PR diff
+- **pinact** - GitHub Actions SHA-pinning check
+- **zizmor** - GitHub Actions static analysis
+
+## How it is enforced
+
+The suite runs on every targeted repo with **no workflow file in that repo**,
+via an organization **ruleset** ("Require workflows to pass before merging")
+that points at:
+
+```
+geolonia/.github/.github/workflows/security-suite.yml@refs/tags/v1
+```
+
+`security-suite.yml` is a thin caller of `reusable-security-suite.yml`, which
+calls the scanner reusables, all pinned to `@v1` so a suite change ships with
+no per-caller bump. The same suite is also offered in the "New workflow" picker
+(`workflow-templates/security-suite.yml`) for repos that opt in manually.
+**Do not enable both on one repo.**
+
+## ⚠️ The one rule you must not forget: keep `v1` a LIGHTWEIGHT tag
+
+**The `v1` tag must be a lightweight tag (a direct ref to a commit), never an
+annotated tag object.**
+
+The ruleset resolves the required workflow at `security-suite.yml@refs/tags/v1`.
+GitHub's "require workflows" **injector cannot resolve an annotated `v1` tag**:
+when `v1` is annotated it **silently produces no run at all** - no check-run,
+not even a failure - and the required "Security Suite" check hangs at
+**"Expected / waiting for workflow to run" forever**, blocking merge on every
+consumer PR. This is not documented by GitHub; it was learned the hard way (the
+v1.27-v1.31 outage). Note the failure is silent - `@v1` moving to a new release
+is **not** proof the gate works.
+
+Check the tag type any time:
+
+```bash
+# Annotated if the two SHAs differ; lightweight if the peel is empty/equal.
+git ls-remote https://github.com/geolonia/.github refs/tags/v1 'refs/tags/v1^{}'
+```
+
+Floating **reusable** refs (`reusable-security-suite.yml@v1`, the scanner
+reusables `@v1`) are **fine** - they are not the tag the ruleset resolves, and
+they resolve normally at runtime. Do not SHA-pin them thinking it fixes an
+"Expected" hang; that was a red herring during the outage.
+
+## What makes `v1` annotated (and how we prevent it)
+
+`v1` is moved by the release workflow (`reusable-release-auto-on-tag.yml`) on
+each `vX.Y.Z` push. If the release tag is **annotated** (`git tag -a`), a naive
+`git tag -f v1 <tag>` copies the annotated object into `v1`. Two guards:
+
+1. **The release workflow peels to the commit** (`git tag -f v1 "$TAG^{commit}"`),
+   so the moved `v1`/minor tags are always lightweight regardless of the release
+   tag's type. This is the durable guard.
+2. **Cut release tags lightweight anyway** (`git tag vX.Y.Z`, not `git tag -a`),
+   as a backstop.
+
+## Releasing a change to the suite
+
+Because everything floats on `@v1`, a suite or scanner change is a **single
+release**, no chain-bump:
+
+1. Edit the reusable (`reusable-security-suite.yml` or a scanner reusable),
+   open a PR, merge.
+2. Cut a `vX.Y.Z` tag on `main` (lightweight). The release workflow moves `v1`
+   (lightweight, per the peel above); every consumer on `@v1` picks it up.
+
+## Verify after every release
+
+`@v1` moving is **not** proof the gate works - the injector failure is silent.
+After releasing, confirm the suite actually runs on a real consumer PR:
+
+```bash
+# Re-trigger an open consumer PR with an empty commit (synchronize event):
+gh api "repos/geolonia/<repo>/actions/runs?head_sha=<head>" \
+  --jq '.workflow_runs[].name'
+# Expect a "Security Suite" run, not just the repo's own CI.
+```
+
+If you see only the repo's own CI and no "Security Suite" run, **check the `v1`
+tag type first** - it is almost always an annotated `v1`.
+
+## geolonia/.github is not a ruleset target
+
+The repo that **hosts** the required workflow must **not** also be in the
+ruleset's target repos. On its own PRs GitHub runs the local branch copy of
+`security-suite.yml` (the normal job checks), but the injected required check
+expects the `@v1` version and hangs at "Expected". Keep `geolonia/.github`
+excluded; it dogfoods the suite via its own `.github/workflows/security-suite.yml`.
+
+## Troubleshooting
+
+See the shared tips in [Reusable Workflow Templates](../workflows.md#troubleshooting).
+The failure mode unique to this suite is the silent "Expected" hang above;
+it is almost always an **annotated `v1` tag**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - Community Health: community-health.md
   - Workflows:
       - Overview: workflows.md
+      - Security Suite: workflows/security-suite.md
       - Publish TechDocs: workflows/publish-techdocs.md
       - Release on Tag: workflows/release-on-tag.md
       - Bumblebee Supply-Chain Scan: workflows/bumblebee-scan.md


### PR DESCRIPTION
Restores the no-treadmill floating setup now that we know the **real** cause of the org-wide Security Suite outage (v1.27–v1.31), and guards against recurrence + documents it.

## Root cause (corrected)
The outage was **not** the floating reusable refs (that was a red herring the SHA-pinning "fixed" without fixing). The `v1` tag became an **annotated tag object** — my `git tag -a` releases got copied into `v1` by the release workflow — and the ruleset "require workflows" **injector can't resolve an annotated `v1`**, so it silently produces no run and the required check hangs at "Expected" forever on every consumer PR. Fixed live by recreating `v1` lightweight (the suite immediately injected on infra-cdk#151).

## Changes
- **Revert reusable refs to `@v1`** in `security-suite.yml` + `reusable-security-suite.yml` (floating is fine; `.pinact.yml`/`zizmor.yml` `@v1` exemptions cover them). → single-release upgrades again, no chain-bump.
- **`reusable-release-auto-on-tag.yml`: peel to commit** (`git tag -f v1 "$TAG^{commit}"`) so moved `v1`/minor tags are **always lightweight**, even if a release tag is annotated. Durable guard against recurrence.
- **`release-auto-on-tag.yml`: float the caller on `@v1`** so it picks up the peel fix.
- **Docs + memory**: new `docs/workflows/security-suite.md` (the `v1`-must-be-lightweight rule, single-release flow, post-release verification, keep-`.github`-out-of-targets), a `workflows.md` callout, mkdocs nav, and the `reusable_workflows` Serena memory. Corrects the earlier wrong "SHA-pin the whole tree" guidance.

## Supersedes #91
#91 documented the wrong cause; closing it in favor of this.

## After merge
Cut **v1.32.0 (lightweight tag!)** → confirm `v1` stays lightweight and the suite still injects on a consumer PR.

Validation: `pinact --check` exit 0, `zizmor` clean, no em-dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release and security workflows to use a lightweight floating `v1` reference, helping required checks run reliably and avoiding stuck statuses.
  * Improved tag handling so release tags resolve consistently during updates.

* **Documentation**
  * Added and expanded documentation for the Security Suite workflow, including setup, verification, troubleshooting, and release guidance.
  * Updated workflow docs navigation and notes about the new Security Suite entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->