### PR TITLE
feat(techdocs): allow AWS account ID via vars (drop caller secrets block)

### DIFF
--- a/.github/workflows/reusable-backstage-techdocs.yml
+++ b/.github/workflows/reusable-backstage-techdocs.yml
@@ -54,11 +54,15 @@ on:
         type: string
 
     secrets:
+      # An AWS account ID is a non-sensitive identifier. Prefer setting it as
+      # an org/repo variable (vars.AWS_ACCOUNT_ID / vars.TECHDOCS_AWS_ACCOUNT_ID),
+      # which reusable workflows read automatically — then the caller needs no
+      # `secrets:` block at all. These secret inputs remain for back-compat.
       AWS_ACCOUNT_ID:
-        description: "Account ID (used to build default role ARN)"
+        description: "Account ID (used to build default role ARN). Prefer vars.AWS_ACCOUNT_ID."
         required: false
       TECHDOCS_AWS_ACCOUNT_ID:
-        description: "Org-level fallback Account ID (if AWS_ACCOUNT_ID not provided)"
+        description: "Org-level fallback Account ID. Prefer the org variable vars.TECHDOCS_AWS_ACCOUNT_ID."
         required: false
 
 env:
@@ -69,7 +73,9 @@ env:
   MKDOCS_CORE_VER:        ${{ inputs.mkdocs_core_version || vars.MKDOCS_TECHDOCS_CORE_VERSION || '>=1.6,<2.0' }}
 
   AWS_REGION:             ${{ inputs.aws_region || vars.AWS_REGION || 'ap-northeast-1' }}
-  AWS_ACCOUNT_ID:         ${{ secrets.AWS_ACCOUNT_ID || secrets.TECHDOCS_AWS_ACCOUNT_ID }}
+  # secrets first (back-compat), then vars — so callers can supply the account
+  # ID via an org/repo variable and omit the `secrets:` block entirely.
+  AWS_ACCOUNT_ID:         ${{ secrets.AWS_ACCOUNT_ID || secrets.TECHDOCS_AWS_ACCOUNT_ID || vars.AWS_ACCOUNT_ID || vars.TECHDOCS_AWS_ACCOUNT_ID }}
 
   TECHDOCS_BUCKET:        ${{ inputs.techdocs_bucket || vars.TECHDOCS_BUCKET || 'geolonia-backstage-techdocs' }}
   TECHDOCS_ENTITY_INPUT:  ${{ inputs.techdocs_entity }}


### PR DESCRIPTION
## Summary

Reusable workflows don't auto-inherit secrets — only the `vars` context. The AWS account ID was the one setting that forced every caller of `reusable-backstage-techdocs.yml` to keep a `secrets:` block (or `secrets: inherit`, which the org Security suite flags via zizmor `secrets-inherit`).

Since an account ID is a non-sensitive identifier — and the org now has a `TECHDOCS_AWS_ACCOUNT_ID` **variable** — this adds a `vars` fallback to the account-ID cascade:

```yaml
AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID || secrets.TECHDOCS_AWS_ACCOUNT_ID || vars.AWS_ACCOUNT_ID || vars.TECHDOCS_AWS_ACCOUNT_ID }}
```

**Back-compat:** secrets are tried first, so existing `secrets:` / `secrets: inherit` callers are unaffected. Callers relying on the org variable can now drop the `secrets:` block entirely:

```yaml
jobs:
  publish:
    permissions:            # irreducible — OIDC requires the caller to grant id-token: write
      contents: read
      id-token: write
    uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@<sha>  # vX
```

Also updates the secret-input descriptions to point at the `vars` alternative.

Closes #94

## Test plan
- [x] YAML valid
- [x] Cascade tries secrets before vars (no behavior change for existing callers)
- [ ] After merge: a consumer with the org variable set and no `secrets:` block publishes TechDocs successfully (verify on the first repo we simplify)

## Follow-up
Simplify individual consumers to drop their `secrets:` block (e.g. geonicdb-infra-cdk's `publish-techdocs.yml`), once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the recommended way to provide AWS account IDs, with guidance to use repository or organization variables when available.

* **Bug Fixes**
  * Improved the default AWS account selection order so it now falls back more reliably when building the OIDC role ARN.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->