### PR TITLE
Harden sync-team-access workflow template (explicit perms + secrets)

### DIFF
--- a/workflow-templates/sync-team-access.yml
+++ b/workflow-templates/sync-team-access.yml
@@ -5,10 +5,21 @@ on:
     branches: [main]
     paths: ['catalog-info.yaml']
 
+# Explicit least-privilege ceiling: the reusable only reads catalog-info.yaml
+# and dispatches via an App token, so the caller token needs no more than
+# contents: read (avoids the repo-default token, which zizmor flags as
+# excessive-permissions).
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: geolonia/.github/.github/workflows/reusable-sync-team-access.yml@92c8c6d56730650205ca4be5c7bdba72245d304f # v1.16.0
-    secrets: inherit
+    # Pass only the dispatch secrets the reusable declares, not
+    # `secrets: inherit` (zizmor secrets-inherit).
+    secrets:
+      OPS_DISPATCH_CLIENT_ID: ${{ secrets.OPS_DISPATCH_CLIENT_ID }}
+      OPS_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
     # Optional settings (uncomment to override defaults):
     # with:
     #   dispatch_repo: geolonia/geolonia-operations


### PR DESCRIPTION
## What

Harden `workflow-templates/sync-team-access.yml` to match the already-hardened `route-issue.yml` template:

- add a `permissions: contents: read` ceiling, and
- pass the `OPS_DISPATCH_CLIENT_ID` / `OPS_DISPATCH_APP_PRIVATE_KEY` dispatch secrets explicitly instead of `secrets: inherit`.

## Why

`sync-team-access.yml` was the last picker template still using `secrets: inherit` with no `permissions:` block, so any repo adopting it from the "New workflow" picker inherited two zizmor findings on first commit:

- `excessive-permissions` (default token, no `permissions:` block)
- `secrets-inherit` (all secrets forwarded unconditionally)

The reusable declares exactly these two secrets (`reusable-sync-team-access.yml` -> `on.workflow_call.secrets`) and needs no more than `contents: read` at the caller (it dispatches via an App token), so the explicit form is a drop-in.

Surfaced while adopting the Security Suite in `geolonia-design-system`, where the same fix was applied to that repo's copy.

## Note

Reusable pin left at its current `v1.16.0` (unchanged); this PR is scoped to the hardening only.