### PR TITLE
chore(betterleaks): bump v1.5.0 → v1.6.1

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -23,7 +23,7 @@ on:
         description: "betterleaks container image, pinned by digest. Override only for testing newer versions."
         type: string
         required: false
-        default: "ghcr.io/betterleaks/betterleaks@sha256:e78fa87a9113506302d7f08698f8e1065c8c5bb363e43b2db058ea4464189922"  # v1.5.0 -- 50 new detection rules; archives scanned by default. Org default.toml verified to parse under the new go-toml config loader.
+        default: "ghcr.io/betterleaks/betterleaks@sha256:7a43a20d40be02a9c13801a6485f7bea9d9cdba512263440eae972103c5291f1"  # v1.6.1 -- CEL to Expr runtime (existing CEL configs still accepted), faster cold start, adds config command. Org default.toml uses regex/path allowlists only, unaffected.
       fail-on-findings:
         description: "Fail the job (block the PR check) when secrets are found. Set false for warn-only mode while a repo cleans up legacy false positives."
         type: boolean

--- a/betterleaks/.pre-commit-config.example.yaml
+++ b/betterleaks/.pre-commit-config.example.yaml
@@ -22,7 +22,7 @@ repos:
   - repo: https://github.com/betterleaks/betterleaks
     # Pin to the same version as the per-PR Secret Leak Check workflow.
     # Bump both together so local and CI use identical rule shapes.
-    rev: v1.5.0
+    rev: v1.6.1
     hooks:
       # Docker variant. Works without a local Go/Rust toolchain. The image
       # is pulled on first use and cached. Mac/Linux developers typically


### PR DESCRIPTION
## What

Bumps the pinned betterleaks version from **v1.5.0** to **v1.6.1** in the two places that must move together:

- `.github/workflows/reusable-secret-leak-check.yml` — the `betterleaks-image` default digest (`sha256:7a43a20d…291f1`, resolved from the `v1.6.1` tag on ghcr.io).
- `betterleaks/.pre-commit-config.example.yaml` — the matching `rev: v1.6.1` so local pre-commit and CI use identical rule shapes.

## Why

v1.6.1 is the current latest release. Highlights across v1.6.0 → v1.6.1:

- **Expr replaces CEL** as the expression runtime. Existing CEL-shaped configs remain accepted for compatibility.
- **Faster cold start** (lazy regex compilation + tokenizer load, 160ms → 20ms) and a smaller binary (30MB → 22.7MB).
- **Rule specificity** for more accurate generic-rule suppression.
- Adds a `config` command; crypto dependency bump.

## Config compatibility

The org `default.toml` uses only `[[allowlists]]` with `regexes`/`paths` — no CEL/Expr expressions — so the runtime migration does not affect it. (v1.6.0 also retains CEL-config compatibility regardless.)

## Verification

- Digest resolution method verified: the same query returns the existing pinned digest for the `v1.5.0` tag, so `v1.6.1` → `sha256:7a43a20d…291f1` is the correct multi-arch index digest.
- Live parse of `default.toml` against the new image was not run here (no local Docker); the config surface is regex/path-only and unaffected, and the reusable workflow's own run will exercise it on the next PR.

Tracking: geolonia/geolonia-operations#203