### PR TITLE
docs(security-suite): record why ref creation is exempt from the workflow rule

### DIFF
--- a/docs/workflows/security-suite.md
+++ b/docs/workflows/security-suite.md
@@ -105,6 +105,30 @@ gh api "repos/geolonia/<repo>/actions/runs?head_sha=<head>" \
 If you see only the repo's own CI and no "Security Suite" run, **check the `v1`
 tag type first** - it is almost always an annotated `v1`.
 
+## Ref creation is exempt, and must stay exempt
+
+The ruleset's workflow rule has **"Do not enforce on creation" enabled**
+(`do_not_enforce_on_create: true` over the REST API). Leave it enabled.
+
+A repository is enrolled by its `security-suite=true` custom property, and that
+property can be set when the repository is created, before it has any commits.
+The first push is the one that creates the default branch, so with the flag off
+the rule is evaluated against a required workflow run that cannot exist yet:
+no branch, no PR, nothing to run. GitHub declines the push with "push declined
+due to repository rule violations", and automated repository provisioning fails
+outright with an empty repo.
+
+The exemption covers the ref creation event only. Every later push and pull
+request to the default branch of an enrolled repo still requires the suite to
+pass, and the ruleset keeps an empty bypass list.
+
+Read the current value with:
+
+```bash
+gh api /orgs/geolonia/rulesets/<ruleset_id> \
+  --jq '.rules[] | select(.type=="workflows") | .parameters.do_not_enforce_on_create'
+```
+
 ## geolonia/.github is not a ruleset target
 
 The repo that **hosts** the required workflow must **not** also be in the


### PR DESCRIPTION
## Context

The `branch-rules: security-suite` org ruleset requires
`.github/workflows/security-suite.yml@refs/tags/v1` on the default branch of every
repo carrying the `security-suite=true` custom property.

Because that property can be set at repository creation time, before the repo has
any commits, the first push is the one that creates the default branch. With
"Do not enforce on creation" disabled, the rule was evaluated against a required
workflow run that cannot exist yet (no branch, no PR, nothing to run), and GitHub
declined the push:

```
refs/heads/main: push declined due to repository rule violations
```

Automated repository provisioning failed outright and left nothing behind.

`do_not_enforce_on_create` is now `true` on the ruleset. Nothing else changed:
still `active`, still scoped to `~DEFAULT_BRANCH` on `security-suite=true` repos,
still an empty bypass list.

## What this PR does

Documents the flag in `docs/workflows/security-suite.md`, next to the other
ruleset configuration notes:

- the flag must stay enabled, and why
- the failure mode it prevents
- that the exemption covers the ref creation event only, so every later push and
  PR to the default branch still requires the suite to pass
- a `gh api` one-liner to read the current value

Docs only. No workflow, scanner, or config behavior changes.

## Why document it

The ruleset is API and UI managed, so this flag lives only in GitHub's state with
nothing in git explaining it. Without a note, a future ruleset review reads
"do not enforce" as a gap and turns it back off, which silently breaks new
repository creation for every enrolled repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on exempting ref creation events from security ruleset enforcement.
  - Clarified that subsequent pushes and pull requests remain subject to the security suite.
  - Documented the `do_not_enforce_on_create` setting and included a command for checking its current value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->