### PR TITLE
chore(secret-leak): bump betterleaks v1.6.1 to v1.7.0

### DIFF
--- a/.github/workflows/reusable-secret-leak-check.yml
+++ b/.github/workflows/reusable-secret-leak-check.yml
@@ -36,7 +36,7 @@ on:
         description: "betterleaks container image, pinned by digest. Override only for testing newer versions."
         type: string
         required: false
-        default: "ghcr.io/betterleaks/betterleaks@sha256:7a43a20d40be02a9c13801a6485f7bea9d9cdba512263440eae972103c5291f1"  # v1.6.1 -- CEL to Expr runtime (existing CEL configs still accepted), faster cold start, adds config command. The org .betterleaks.toml base uses regex/path allowlists only, unaffected.
+        default: "ghcr.io/betterleaks/betterleaks@sha256:bca7945ad3a69a5df4fc5960a575e9b03238f04acd8ac28c5bd0d588cbe0b33f"  # v1.7.0 -- ruleset grows 325 to 412 rules (87 new detectors, 187 with validation); the generic rule now filters public-by-design credentials; no config-schema change. Verified against the org base and the audit [extend] overlay: byte-identical scans, no new findings.
       fail-on-findings:
         description: "Fail the job (block the PR check) when secrets are found. Set false for warn-only mode while a repo cleans up legacy false positives."
         type: boolean


### PR DESCRIPTION
## What

Bumps the default betterleaks image in `reusable-secret-leak-check.yml` from v1.6.1 to v1.7.0.

```diff
-  # v1.6.1
-  default: "ghcr.io/betterleaks/betterleaks@sha256:7a43a20d...c5291f1"
+  # v1.7.0
+  default: "ghcr.io/betterleaks/betterleaks@sha256:bca7945a...cbe0b33f"
```

## What is in v1.7.0

- default ruleset grows from **325 rules to 412** (87 new detectors; 187 now carry validation, up from 106)
- the generic rule now filters public-by-design credentials that reach no sensitive data or privileged operations
- support for quoted and escaped values in `--log-opts`
- scan times down 8.6% to 37.1%
- **no config-schema change**

## Why this needed testing before pinning

The schema is not the risk. The 87 new detectors are. This workflow gates pull requests across every enrolled repo, so a version that starts producing findings fails everyone's CI at once, and the failures would look unrelated to whatever change is under review.

Verified locally, v1.6.1 against v1.7.0:

| Check | v1.6.1 | v1.7.0 |
|---|---|---|
| canonical base config parses | yes | yes |
| audit `[extend]` overlay parses (base + `disabledRules`) | yes | yes |
| scan: datastore tree (284334 bytes) | no leaks | no leaks |
| scan: sitestore tree (375521 bytes) | no leaks | no leaks |
| scan: n8n tree (141879 bytes) | no leaks | no leaks |

Byte counts are identical across versions, so both scanned the same surface. Trees were exported with `git archive HEAD` so only tracked files were scanned.

The `[extend]` overlay matters specifically: the weekly audit layers `disabledRules = ["generic-api-key"]` on top of the fetched base, and that is the part most likely to break on a config change.

## Pin detail

Pinned to the **index digest**, matching the existing pin. Note that `docker image inspect` after a `--platform linux/amd64` pull returns the platform-specific manifest digest (`sha256:06d60954...`) rather than the index digest. Using that would work on the amd64 runners but silently break any non-amd64 caller.

## Follow-up

The weekly audit in the operations repo pins the same digest independently and needs the matching bump. That is a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default secret leak detection tool to a newer, pinned version.
  * Improved the reliability and security of automated secret scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->