### PR TITLE
docs: drop secrets: inherit from remaining consumer examples

### DIFF
--- a/.github/workflows/reusable-route-issue.yml
+++ b/.github/workflows/reusable-route-issue.yml
@@ -26,7 +26,11 @@ name: "[REUSABLE] Route issue to team board"
 #   jobs:
 #     route:
 #       uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
-#       secrets: inherit
+#       # Pass only the dispatch secrets this workflow declares, not
+#       # `secrets: inherit` (zizmor secrets-inherit).
+#       secrets:
+#         OPS_DISPATCH_CLIENT_ID: ${{ secrets.OPS_DISPATCH_CLIENT_ID }}
+#         OPS_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
 #
 # Requires the org-level dispatch secrets (already used by sync-team-access) to
 # be visible to the calling repo:

--- a/.serena/memories/reusable_workflows.md
+++ b/.serena/memories/reusable_workflows.md
@@ -46,7 +46,15 @@ Consumers should pin to a tag, not a SHA, not `@main`:
 jobs:
   publish:
     uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@v1
-    secrets: inherit
+```
+
+When a reusable declares secrets, pass exactly those — never `secrets: inherit`
+(zizmor secrets-inherit):
+
+```yaml
+    secrets:
+      OPS_DISPATCH_CLIENT_ID: ${{ secrets.OPS_DISPATCH_CLIENT_ID }}
+      OPS_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
 ```
 
 ## Updating a reusable workflow

--- a/.serena/memories/reusable_workflows.md
+++ b/.serena/memories/reusable_workflows.md
@@ -48,8 +48,9 @@ jobs:
     uses: geolonia/.github/.github/workflows/reusable-backstage-techdocs.yml@v1
 ```
 
-When a reusable declares secrets, pass exactly those — never `secrets: inherit`
-(zizmor secrets-inherit):
+When a reusable declares secrets, pass exactly the ones its `workflow_call`
+contract declares — never `secrets: inherit` (zizmor secrets-inherit). For
+example, `reusable-route-issue.yml` declares the two dispatch secrets:
 
 ```yaml
     secrets:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -77,9 +77,10 @@ From the UI: **Actions → select the workflow → Run workflow**.
 
 - Confirm the secret is set under **Settings → Secrets and variables → Actions**
   in the calling repository.
-- Reusable workflows called with `secrets: inherit` receive all secrets from the
-  caller. If a secret is set at the org level, the calling repo must have access
-  to it (check org secret visibility).
+- Callers pass secrets explicitly (`secrets:` mapping, not `secrets: inherit`),
+  so check the caller forwards the secret the reusable declares. If a secret is
+  set at the org level, the calling repo must have access to it (check org
+  secret visibility).
 - For workflows that override `AWS_ACCOUNT_ID`, make sure the repo-level secret
   name matches exactly (it is case-sensitive).
 

--- a/docs/workflows/route-issue.md
+++ b/docs/workflows/route-issue.md
@@ -20,7 +20,11 @@ permissions:
 jobs:
   route:
     uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
-    secrets: inherit
+    # Pass only the dispatch secrets the reusable declares, not
+    # `secrets: inherit` (zizmor secrets-inherit).
+    secrets:
+      OPS_DISPATCH_CLIENT_ID: ${{ secrets.OPS_DISPATCH_CLIENT_ID }}
+      OPS_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
 ```
 
 ## Options
@@ -33,7 +37,9 @@ jobs:
 jobs:
   route:
     uses: geolonia/.github/.github/workflows/reusable-route-issue.yml@v1
-    secrets: inherit
+    secrets:
+      OPS_DISPATCH_CLIENT_ID: ${{ secrets.OPS_DISPATCH_CLIENT_ID }}
+      OPS_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.OPS_DISPATCH_APP_PRIVATE_KEY }}
     with:
       exclusive_routing: false   # add only, never remove
 ```


### PR DESCRIPTION
## Summary

Follow-up to geolonia/geonicdb-deployments#30: the workflow templates were already hardened to pass dispatch secrets explicitly, but several documented consumer examples still recommended `secrets: inherit`, so repos that copy them keep getting zizmor `secrets-inherit` warnings (CodeRabbit flagged this in geolonia/geonicdb-deployments#23).

Changes (docs/comments only, no workflow behavior changes):

- `.github/workflows/reusable-route-issue.yml` — header consumer example now shows the explicit two-secret mapping
- `docs/workflows/route-issue.md` — both usage examples updated the same way
- `docs/workflows.md` — troubleshooting note reworded: callers pass secrets explicitly, so check the caller forwards the declared secret
- `.serena/memories/reusable_workflows.md` — caller-side conventions now state the explicit-mapping rule (and the techdocs pinning example no longer shows a secrets line, since that reusable needs none)

All remaining `secrets: inherit` mentions in the repo are negative guidance ("do not use").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated reusable workflow guidance to require explicitly passing declared secrets.
  - Replaced inherited secrets with explicit mappings for operations dispatch credentials in workflow examples.
  - Added troubleshooting guidance for secret visibility and configuration.
  - Clarified the required secret mappings in all relevant workflow documentation.
- **Chores**
  - Updated the reusable workflow example to use only the required secrets, improving configuration clarity and control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->