### PR TITLE
chore(dependabot): ignore own reusables referenced at a bare major tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,27 @@ updates:
     # check).
     cooldown:
       default-days: 8
+    # This repo references some of its OWN reusables at a bare major tag
+    # (@v1) on purpose: a vX.Y.Z release fast-forwards v1, so the security
+    # suite and the release workflow ship a change in one release instead of
+    # a caller-bump-per-release treadmill. See docs/workflows/security-suite.md
+    # and the matching exemptions in .pinact.yml / zizmor.yml.
+    #
+    # Dependabot does not know that and "upgrades" @v1 to @vX.Y.Z (PR #112),
+    # which breaks the single-release model AND silently loses the .pinact.yml
+    # exemption, because that rule only matches a bare major tag
+    # (ActionVersion "^v[0-9]+$") — so pinact then demands a SHA pin.
+    #
+    # Ignore exactly the reusables referenced at @v1. Listed individually, not
+    # as geolonia/.github/*, because this repo also SHA-pins two of its own
+    # reusables as a consumer would (publish-techdocs.yml, route-issue.yml);
+    # those must keep getting SHA bumps.
+    ignore:
+      - dependency-name: "geolonia/.github/.github/workflows/reusable-security-suite.yml"
+      - dependency-name: "geolonia/.github/.github/workflows/reusable-bumblebee-scan.yml"
+      - dependency-name: "geolonia/.github/.github/workflows/reusable-secret-leak-check.yml"
+      - dependency-name: "geolonia/.github/.github/workflows/reusable-pinact-check.yml"
+      - dependency-name: "geolonia/.github/.github/workflows/reusable-release-auto-on-tag.yml"
     groups:
       # Batch minor and patch bumps into a single weekly PR. Majors are
       # excluded here, so breaking upgrades arrive as individual PRs that


### PR DESCRIPTION
## Summary

Stops Dependabot from regenerating #112, which rewrote this repo's deliberate `@v1` self-references to `@v1.36.0`.

Why that change was wrong:

- `docs/workflows/security-suite.md` documents that `security-suite.yml` → `reusable-security-suite.yml` → the scanner reusables all float on `@v1`, so a suite change ships in **one** release instead of a caller-bump-per-release treadmill.
- `.pinact.yml` exempts `geolonia/*` from SHA-pinning **only at a bare major tag** (`ActionVersion matches "^v[0-9]+$"`). `v1.36.0` does not match, so the pin silently drops out of the exemption — which is why pinact flagged `reusable-security-suite.yml:59` on that PR.
- CodeRabbit's suggested remedy there (SHA-pin all five) is contradicted by our own docs: "Do not SHA-pin them thinking it fixes an 'Expected' hang; that was a red herring during the outage."

## What this does

Ignores the five reusables this repo references at `@v1`:

- `reusable-security-suite.yml`
- `reusable-bumblebee-scan.yml`
- `reusable-secret-leak-check.yml`
- `reusable-pinact-check.yml`
- `reusable-release-auto-on-tag.yml`

They are listed individually rather than as `geolonia/.github/*` on purpose. This repo also SHA-pins two of its own reusables the way a consumer would — `publish-techdocs.yml` → `reusable-backstage-techdocs.yml` and `route-issue.yml` → `reusable-route-issue.yml` — and those must keep receiving SHA bumps. A wildcard would freeze them.

## Verification

- `.github/dependabot.yml` parses; the `cooldown` and `groups` blocks are unchanged.
- Confirmed each of the five ignored reusables is referenced **only** at `@v1` in `.github/workflows/`, and that the two SHA-pinned references are **not** matched by any ignore entry.
- Effect is verifiable on the next weekly Dependabot run: the `@v1` lines should no longer be proposed, while the two SHA pins should still be offered a bump to v1.37.0 once it clears the 8-day cooldown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to skip selected reusable workflow references while continuing updates for other GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->